### PR TITLE
Add rate limiting to the Go SDK

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -248,6 +248,7 @@ func (h *handler) register(w http.ResponseWriter, r *http.Request) error {
 			Slug:        fn.Slug(),
 			Idempotency: c.Idempotency,
 			Triggers:    []inngest.Trigger{{}},
+			RateLimit:   fn.Config().GetRateLimit(),
 			Steps: map[string]sdk.SDKStep{
 				"step": {
 					ID:      "step",

--- a/handler_test.go
+++ b/handler_test.go
@@ -53,6 +53,7 @@ func TestRegister(t *testing.T) {
 			return nil, nil
 		},
 	)
+
 	Register(a, b)
 }
 


### PR DESCRIPTION
Adds the RateLimit config option to function definitions.