### PR TITLE
Fix reported URL

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -221,8 +221,15 @@ func (h *handler) register(w http.ResponseWriter, r *http.Request) error {
 	h.l.Lock()
 	defer h.l.Unlock()
 
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	host := r.Host
+	path := r.URL.String()
+
 	config := sdk.RegisterRequest{
-		URL:        r.URL.String(),
+		URL:        fmt.Sprintf("%s://%s%s", scheme, host, path),
 		V:          "1",
 		DeployType: "ping",
 		SDK:        "go:v0.0.1",


### PR DESCRIPTION
Before this change, the code was reporting relative url such as `/api/inngest` to dev server. This fixes it to have the correct url for discovery.

This fixes #18 for me, but beware that I only tested it locally with Dev Server.

Edit: I'm using this on production and it seems to work with Inngest Cloud as well