### PR TITLE
Spec conformance: app ID prefixes, data wrapping (backcompat)

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -268,7 +268,7 @@ func (h *handler) register(w http.ResponseWriter, r *http.Request) error {
 
 		f := sdk.SDKFunction{
 			Name:        fn.Name(),
-			Slug:        fn.Slug(),
+			Slug:        h.appName + "-" + fn.Slug(),
 			Idempotency: c.Idempotency,
 			Priority:    fn.Config().Priority,
 			Triggers:    []inngest.Trigger{{}},

--- a/handler_test.go
+++ b/handler_test.go
@@ -350,14 +350,14 @@ func TestSteps(t *testing.T) {
 		EventTrigger("test/event.a", nil),
 		func(ctx context.Context, input Input[EventA]) (any, error) {
 			atomic.AddInt32(&fnCt, 1)
-			stepA := step.Run(ctx, "First step", func(ctx context.Context) (map[string]any, error) {
+			stepA, _ := step.Run(ctx, "First step", func(ctx context.Context) (map[string]any, error) {
 				atomic.AddInt32(&aCt, 1)
 				return map[string]any{
 					"test": true,
 					"foo":  input.Event.Data.Foo,
 				}, nil
 			})
-			stepB := step.Run(ctx, "Second step", func(ctx context.Context) (map[string]any, error) {
+			stepB, _ := step.Run(ctx, "Second step", func(ctx context.Context) (map[string]any, error) {
 				atomic.AddInt32(&bCt, 1)
 				return map[string]any{
 					"b": "lol",
@@ -405,7 +405,11 @@ func TestSteps(t *testing.T) {
 			stepA = map[string]any{}
 			err = json.Unmarshal(opcode.Data, &stepA)
 			require.NoError(t, err)
-			require.EqualValues(t, map[string]any{"test": true, "foo": "potato"}, stepA)
+			require.EqualValues(t, map[string]any{
+				"data": map[string]any{
+					"test": true, "foo": "potato",
+				},
+			}, stepA)
 		})
 
 		t.Run("It invokes the second step if the first step's data is passed in", func(t *testing.T) {
@@ -436,8 +440,11 @@ func TestSteps(t *testing.T) {
 			err = json.Unmarshal(opcode.Data, &stepB)
 			require.NoError(t, err)
 			require.EqualValues(t, map[string]any{
-				"b": "lol",
-				"a": stepA,
+				// data is wrapped in an object to conform to the spec.
+				"data": map[string]any{
+					"b": "lol",
+					"a": stepA["data"],
+				},
 			}, stepB)
 
 		})

--- a/step/run.go
+++ b/step/run.go
@@ -17,6 +17,11 @@ type RunOpts struct {
 	Name string
 }
 
+type response struct {
+	Data  json.RawMessage `json:"data"`
+	Error json.RawMessage `json:"error"`
+}
+
 // StepRun runs any code reliably, with retries, returning the resulting data.  If this
 // fails the function stops.
 //
@@ -25,21 +30,40 @@ func Run[T any](
 	ctx context.Context,
 	id string,
 	f func(ctx context.Context) (T, error),
-) T {
+) (T, error) {
 	mgr := preflight(ctx)
 	op := mgr.NewOp(enums.OpcodeStep, id, nil)
 
 	if val, ok := mgr.Step(op); ok {
-		// This step has already ran as we have state for it.
-		// Unmarshal the JSON into type T
+		// Create a new empty type T in v
 		ft := reflect.TypeOf(f)
 		v := reflect.New(ft.Out(0)).Interface()
+
+		// This step has already ran as we have state for it. Unmarshal the JSON into type T
+		unwrapped := response{}
+		if err := json.Unmarshal(val, &unwrapped); err == nil {
+			// Check for step errors first.
+			if len(unwrapped.Error) > 0 {
+				val, _ := reflect.ValueOf(v).Elem().Interface().(T)
+				// xxx: improve this error
+				return val, fmt.Errorf("step error: %s", string(unwrapped.Error))
+			}
+
+			// If there's an error, assume that val is already of type T without wrapping
+			// in the 'data' object as per the SDK spec.  Here, if this succeeds we can be
+			// sure that we're wrapping the data in a compliant way.
+			if len(unwrapped.Data) > 0 {
+				val = unwrapped.Data
+			}
+		}
+
+		// Grab the data as the step type.
 		if err := json.Unmarshal(val, v); err != nil {
 			mgr.SetErr(fmt.Errorf("error unmarshalling state for step '%s': %w", id, err))
 			panic(ControlHijack{})
 		}
 		val, _ := reflect.ValueOf(v).Elem().Interface().(T)
-		return val
+		return val, nil
 	}
 
 	// We're calling a function, so always cancel the context afterwards so that no
@@ -48,11 +72,15 @@ func Run[T any](
 
 	result, err := f(ctx)
 	if err != nil {
+		// TODO: Implement step errors.
 		mgr.SetErr(err)
 		panic(ControlHijack{})
 	}
 
-	byt, err := json.Marshal(result)
+	// Spec RFC:  always wrap the response in a data object.
+	byt, err := json.Marshal(map[string]any{
+		"data": result,
+	})
 	if err != nil {
 		mgr.SetErr(fmt.Errorf("unable to marshal run respone for '%s': %w", id, err))
 	}


### PR DESCRIPTION
Adds data wrapping as per the new SDK spec, and ensures that fns have their app name prefixed.

Fixes #24 