### PR TITLE
Add trust probe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible => gith
 require (
 	github.com/gosimple/slug v1.12.0
 	github.com/gowebpki/jcs v1.0.0
-	github.com/inngest/inngest v0.29.4-0.20240715161914-8a28f85fdcdc
+	github.com/inngest/inngest v0.29.4-0.20240726163936-6b26ad286424
 	github.com/stretchr/testify v1.9.0
 	github.com/xhit/go-str2duration/v2 v2.1.0
 	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f
@@ -37,7 +37,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.10.0 // indirect
 	github.com/hashicorp/terraform v0.15.3 // indirect
-	github.com/inngest/expr v0.0.0-20240521153320-6f549d6745fd // indirect
+	github.com/inngest/expr v0.0.0-20240717151033-03e4378c436c // indirect
 	github.com/karlseguin/ccache/v2 v2.0.8 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -314,10 +314,10 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/inngest/expr v0.0.0-20240521153320-6f549d6745fd h1:zVlqAmiuWBYO8O5T8Rxin4qfqD0YrFQyK/als0w9LS0=
-github.com/inngest/expr v0.0.0-20240521153320-6f549d6745fd/go.mod h1:Dq8dNC1Q/cZBjl6ltxCoAeNn8fstrBJWWjeSisqTL94=
-github.com/inngest/inngest v0.29.4-0.20240715161914-8a28f85fdcdc h1:X028+6/1qaIsPgpajm21VtBeQ0RqBh/7pOjS7HX9prw=
-github.com/inngest/inngest v0.29.4-0.20240715161914-8a28f85fdcdc/go.mod h1:iK3qBNrXQ0Yc2YrvMtGhGc8T/LE087PL4xmKfSDYPms=
+github.com/inngest/expr v0.0.0-20240717151033-03e4378c436c h1:9XaJS0BV+5wYqv3pVh9OxowUPArRdGMRa8xFdV7eTAI=
+github.com/inngest/expr v0.0.0-20240717151033-03e4378c436c/go.mod h1:Dq8dNC1Q/cZBjl6ltxCoAeNn8fstrBJWWjeSisqTL94=
+github.com/inngest/inngest v0.29.4-0.20240726163936-6b26ad286424 h1:VBblOc73gbvDH5R8tUUAxIgIC6facO4xbeTjiTD+BSk=
+github.com/inngest/inngest v0.29.4-0.20240726163936-6b26ad286424/go.mod h1:9pxjip9DyfRcRyuas5iX8yM6UP9WMUcBy0NdVa5JfFc=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=

--- a/handler.go
+++ b/handler.go
@@ -645,8 +645,9 @@ type insecureIntrospection struct {
 
 type secureIntrospection struct {
 	insecureIntrospection
-	SigningKeyFallbackHash *string `json:"signing_key_fallback_hash"`
-	SigningKeyHash         *string `json:"signing_key_hash"`
+	Capabilities           sdk.Capabilities `json:"capabilities"`
+	SigningKeyFallbackHash *string          `json:"signing_key_fallback_hash"`
+	SigningKeyHash         *string          `json:"signing_key_hash"`
 }
 
 func (h *handler) introspect(w http.ResponseWriter, r *http.Request) error {
@@ -693,6 +694,7 @@ func (h *handler) introspect(w http.ResponseWriter, r *http.Request) error {
 				HasSigningKey: h.GetSigningKey() != "",
 				Mode:          mode,
 			},
+			Capabilities:           capabilities,
 			SigningKeyFallbackHash: signingKeyFallbackHash,
 			SigningKeyHash:         signingKeyHash,
 		}

--- a/handler.go
+++ b/handler.go
@@ -38,6 +38,10 @@ var (
 	// DefaultMaxBodySize is the default maximum size read within a single incoming
 	// invoke request (100MB).
 	DefaultMaxBodySize = 1024 * 1024 * 100
+
+	capabilities = sdk.Capabilities{
+		TrustProbe: true,
+	}
 )
 
 const (
@@ -234,6 +238,12 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	case http.MethodPost:
+		probe := r.URL.Query().Get("probe")
+		if probe == "trust" {
+			h.trust(r.Context(), w, r)
+			return
+		}
+
 		if err := h.invoke(w, r); err != nil {
 			_ = publicerr.WriteHTTP(w, err)
 		}
@@ -285,6 +295,7 @@ func (h *handler) register(w http.ResponseWriter, r *http.Request) error {
 			Env:      h.GetEnv(),
 			Platform: platform(),
 		},
+		Capabilities: capabilities,
 	}
 
 	for _, fn := range h.funcs {
@@ -475,7 +486,7 @@ func (h *handler) invoke(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	if valid, err := ValidateSignature(
+	if valid, _, err := ValidateSignature(
 		r.Context(),
 		sig,
 		h.GetSigningKey(),
@@ -647,7 +658,7 @@ func (h *handler) introspect(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	sig := r.Header.Get(HeaderKeySignature)
-	valid, _ := ValidateSignature(
+	valid, _, _ := ValidateSignature(
 		r.Context(),
 		sig,
 		h.GetSigningKey(),
@@ -700,6 +711,57 @@ func (h *handler) introspect(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set(HeaderKeyContentType, "application/json")
 	return json.NewEncoder(w).Encode(introspection)
 
+}
+
+type trustProbeResponse struct {
+	Error *string `json:"error,omitempty"`
+}
+
+func (h *handler) trust(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	w.Header().Add("Content-Type", "application/json")
+	sig := r.Header.Get(HeaderKeySignature)
+	if sig == "" {
+		_ = publicerr.WriteHTTP(w, publicerr.Error{
+			Message: fmt.Sprintf("missing %s header", HeaderKeySignature),
+			Status:  401,
+		})
+		return
+	}
+
+	valid, key, err := ValidateSignature(
+		ctx,
+		r.Header.Get("X-Inngest-Signature"),
+		h.GetSigningKey(),
+		h.GetSigningKeyFallback(),
+		[]byte{},
+	)
+	if err != nil {
+		_ = publicerr.WriteHTTP(w, publicerr.Error{
+			Message: fmt.Sprintf("error validating signature: %s", err),
+		})
+		return
+	}
+	if !valid {
+		_ = publicerr.WriteHTTP(w, publicerr.Error{
+			Message: "invalid signature",
+			Status:  401,
+		})
+		return
+	}
+
+	byt, err := json.Marshal(trustProbeResponse{})
+	if err != nil {
+		_ = publicerr.WriteHTTP(w, err)
+		return
+	}
+
+	w.Header().Add("X-Inngest-Signature", Sign(ctx, time.Now(), []byte(key), byt))
+	w.WriteHeader(200)
+	w.Write(byt)
 }
 
 type StreamResponse struct {

--- a/handler.go
+++ b/handler.go
@@ -761,7 +761,10 @@ func (h *handler) trust(
 
 	w.Header().Add("X-Inngest-Signature", Sign(ctx, time.Now(), []byte(key), byt))
 	w.WriteHeader(200)
-	w.Write(byt)
+	_, err = w.Write(byt)
+	if err != nil {
+		h.Logger.Error("error writing trust probe response", "error", err)
+	}
 }
 
 type StreamResponse struct {

--- a/handler_test.go
+++ b/handler_test.go
@@ -511,6 +511,9 @@ func TestIntrospection(t *testing.T) {
 		signingKeyFallbackHash, err := hashedSigningKey([]byte(testKeyFallback))
 		r.NoError(err)
 		r.Equal(map[string]any{
+			"capabilities": map[string]any{
+				"trust_probe": true,
+			},
 			"function_count":            float64(1),
 			"has_event_key":             false,
 			"has_signing_key":           true,

--- a/signature_test.go
+++ b/signature_test.go
@@ -36,18 +36,18 @@ func TestValidateSignature(t *testing.T) {
 
 	t.Run("failures", func(t *testing.T) {
 		t.Run("With an invalid sig it fails", func(t *testing.T) {
-			ok, err := ValidateSignature(ctx, "lol", testKey, "", testBody)
+			ok, _, err := ValidateSignature(ctx, "lol", testKey, "", testBody)
 			require.False(t, ok)
 			require.ErrorContains(t, err, "invalid signature")
 		})
 		t.Run("With an invalid ts it fails", func(t *testing.T) {
-			ok, err := ValidateSignature(ctx, "t=what&s=yea", testKey, "", testBody)
+			ok, _, err := ValidateSignature(ctx, "t=what&s=yea", testKey, "", testBody)
 			require.False(t, ok)
 			require.ErrorContains(t, err, "invalid timestamp")
 		})
 		t.Run("With an expired ts it fails", func(t *testing.T) {
 			ts := time.Now().Add(-1 * time.Hour).Unix()
-			ok, err := ValidateSignature(ctx, fmt.Sprintf("t=%d&s=yea", ts), testKey, "", testBody)
+			ok, _, err := ValidateSignature(ctx, fmt.Sprintf("t=%d&s=yea", ts), testKey, "", testBody)
 			require.False(t, ok)
 			require.ErrorContains(t, err, "expired signature")
 		})
@@ -56,7 +56,7 @@ func TestValidateSignature(t *testing.T) {
 			at := time.Now()
 			sig := Sign(ctx, at, []byte(testKey), testBody)
 
-			ok, err := ValidateSignature(ctx, sig, "signkey-test-lolwtf", "", testBody)
+			ok, _, err := ValidateSignature(ctx, sig, "signkey-test-lolwtf", "", testBody)
 			require.False(t, ok)
 			require.ErrorContains(t, err, "invalid signature")
 		})
@@ -66,7 +66,7 @@ func TestValidateSignature(t *testing.T) {
 		at := time.Now().Add(-5 * time.Second)
 		sig := Sign(ctx, at, []byte(testKey), testBody)
 
-		ok, err := ValidateSignature(ctx, sig, testKey, "", testBody)
+		ok, _, err := ValidateSignature(ctx, sig, testKey, "", testBody)
 		require.True(t, ok)
 		require.NoError(t, err)
 	})

--- a/vendor/github.com/inngest/expr/engine.go
+++ b/vendor/github.com/inngest/expr/engine.go
@@ -13,7 +13,7 @@ const (
 
 	EngineTypeStringHash
 	EngineTypeNullMatch
-	EngineTypeBTree // TODO
+	EngineTypeBTree
 	// EngineTypeART
 )
 

--- a/vendor/github.com/inngest/inngest/pkg/expressions/aggregator.go
+++ b/vendor/github.com/inngest/inngest/pkg/expressions/aggregator.go
@@ -23,6 +23,7 @@ type EventEvaluable interface {
 func NewAggregator(
 	ctx context.Context,
 	size int64,
+	concurrency int64,
 	loader EvaluableLoader,
 	log *slog.Logger,
 ) Aggregator {
@@ -94,9 +95,10 @@ type aggregator struct {
 
 	records *ccache.Cache
 
-	loader    EvaluableLoader
-	parser    expr.TreeParser
-	evaluator expr.ExpressionEvaluator
+	concurrency int64
+	loader      EvaluableLoader
+	parser      expr.TreeParser
+	evaluator   expr.ExpressionEvaluator
 
 	mapLock *sync.Mutex
 	locks   map[string]*sync.Mutex
@@ -146,7 +148,7 @@ func (a *aggregator) LoadEventEvaluator(ctx context.Context, wsID uuid.UUID, eve
 		bk = &bookkeeper{
 			wsID:  wsID,
 			event: eventName,
-			ae:    expr.NewAggregateEvaluator(a.parser, a.evaluator, a.loader.EvaluablesByID),
+			ae:    expr.NewAggregateEvaluator(a.parser, a.evaluator, a.loader.EvaluablesByID, a.concurrency),
 			// updatedAt is a zero time.
 		}
 

--- a/vendor/github.com/inngest/inngest/pkg/sdk/sdk.go
+++ b/vendor/github.com/inngest/inngest/pkg/sdk/sdk.go
@@ -84,7 +84,6 @@ type RegisterRequest struct {
 }
 
 type Capabilities struct {
-	InBandSync bool `json:"in_band_sync"`
 	TrustProbe bool `json:"trust_probe"`
 }
 

--- a/vendor/github.com/inngest/inngest/pkg/sdk/sdk.go
+++ b/vendor/github.com/inngest/inngest/pkg/sdk/sdk.go
@@ -79,6 +79,13 @@ type RegisterRequest struct {
 
 	// checksum is a memoized field.
 	checksum string
+
+	Capabilities Capabilities `json:"capabilities"`
+}
+
+type Capabilities struct {
+	InBandSync bool `json:"in_band_sync"`
+	TrustProbe bool `json:"trust_probe"`
 }
 
 type Headers struct {

--- a/vendor/github.com/inngest/inngest/pkg/syscode/codes.go
+++ b/vendor/github.com/inngest/inngest/pkg/syscode/codes.go
@@ -5,7 +5,12 @@ const (
 	CodeComboUnsupported          = "combo_unsupported"
 	CodeConcurrencyLimitInvalid   = "concurrency_limit_invalid"
 	CodeConfigInvalid             = "config_invalid"
+	CodeHTTPMissingHeader         = "http_missing_header"
+	CodeHTTPNotOK                 = "http_not_ok"
+	CodeHTTPUnreachable           = "http_unreachable"
+	CodeNotSDK                    = "not_sdk"
 	CodeOutputTooLarge            = "output_too_large"
+	CodeSigVerificationFailed     = "sig_verification_failed"
 	CodeUnknown                   = "unknown"
 	CodeBatchKeyExpressionInvalid = "batch_key_expression_invalid"
 )

--- a/vendor/github.com/inngest/inngest/pkg/syscode/error.go
+++ b/vendor/github.com/inngest/inngest/pkg/syscode/error.go
@@ -66,6 +66,19 @@ func messageFromMultiErrData(data []byte) (string, error) {
 	return out, nil
 }
 
+// Used to structure Error.Data when there was an HTTP-related error
+type DataHTTPErr struct {
+	Headers    map[string][]string `json:"headers"`
+	StatusCode int                 `json:"status_code"`
+}
+
+func (d DataHTTPErr) ToMap() map[string]any {
+	return map[string]any{
+		"headers":     d.Headers,
+		"status_code": d.StatusCode,
+	}
+}
+
 // Used to structure Error.Data when there are multiple errors (e.g.
 // synchronization validation)
 type DataMultiErr struct {

--- a/vendor/github.com/inngest/inngest/pkg/telemetry/histogram.go
+++ b/vendor/github.com/inngest/inngest/pkg/telemetry/histogram.go
@@ -74,3 +74,14 @@ func HistogramQueuePeekEWMA(ctx context.Context, value int64, opts HistogramOpt)
 		Boundaries:  peekSizeBoundaries,
 	})
 }
+
+func HistogramRedisCommandDuration(ctx context.Context, value int64, opts HistogramOpt) {
+	RecordIntHistogramMetric(ctx, value, HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "redis_command_duration",
+		Description: "Redis command duration",
+		Tags:        opts.Tags,
+		Unit:        "ms",
+		Boundaries:  DefaultBoundaries,
+	})
+}

--- a/vendor/golang.org/x/sync/semaphore/semaphore.go
+++ b/vendor/golang.org/x/sync/semaphore/semaphore.go
@@ -1,0 +1,160 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semaphore provides a weighted semaphore implementation.
+package semaphore // import "golang.org/x/sync/semaphore"
+
+import (
+	"container/list"
+	"context"
+	"sync"
+)
+
+type waiter struct {
+	n     int64
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+// NewWeighted creates a new weighted semaphore with the given
+// maximum combined weight for concurrent access.
+func NewWeighted(n int64) *Weighted {
+	w := &Weighted{size: n}
+	return w
+}
+
+// Weighted provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type Weighted struct {
+	size    int64
+	cur     int64
+	mu      sync.Mutex
+	waiters list.List
+}
+
+// Acquire acquires the semaphore with a weight of n, blocking until resources
+// are available or ctx is done. On success, returns nil. On failure, returns
+// ctx.Err() and leaves the semaphore unchanged.
+func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+	done := ctx.Done()
+
+	s.mu.Lock()
+	select {
+	case <-done:
+		// ctx becoming done has "happened before" acquiring the semaphore,
+		// whether it became done before the call began or while we were
+		// waiting for the mutex. We prefer to fail even if we could acquire
+		// the mutex without blocking.
+		s.mu.Unlock()
+		return ctx.Err()
+	default:
+	}
+	if s.size-s.cur >= n && s.waiters.Len() == 0 {
+		// Since we hold s.mu and haven't synchronized since checking done, if
+		// ctx becomes done before we return here, it becoming done must have
+		// "happened concurrently" with this call - it cannot "happen before"
+		// we return in this branch. So, we're ok to always acquire here.
+		s.cur += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.size {
+		// Don't make other Acquire calls block on one that's doomed to fail.
+		s.mu.Unlock()
+		<-done
+		return ctx.Err()
+	}
+
+	ready := make(chan struct{})
+	w := waiter{n: n, ready: ready}
+	elem := s.waiters.PushBack(w)
+	s.mu.Unlock()
+
+	select {
+	case <-done:
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.
+			// Pretend we didn't and put the tokens back.
+			s.cur -= n
+			s.notifyWaiters()
+		default:
+			isFront := s.waiters.Front() == elem
+			s.waiters.Remove(elem)
+			// If we're at the front and there're extra tokens left, notify other waiters.
+			if isFront && s.size > s.cur {
+				s.notifyWaiters()
+			}
+		}
+		s.mu.Unlock()
+		return ctx.Err()
+
+	case <-ready:
+		// Acquired the semaphore. Check that ctx isn't already done.
+		// We check the done channel instead of calling ctx.Err because we
+		// already have the channel, and ctx.Err is O(n) with the nesting
+		// depth of ctx.
+		select {
+		case <-done:
+			s.Release(n)
+			return ctx.Err()
+		default:
+		}
+		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	success := s.size-s.cur >= n && s.waiters.Len() == 0
+	if success {
+		s.cur += n
+	}
+	s.mu.Unlock()
+	return success
+}
+
+// Release releases the semaphore with a weight of n.
+func (s *Weighted) Release(n int64) {
+	s.mu.Lock()
+	s.cur -= n
+	if s.cur < 0 {
+		s.mu.Unlock()
+		panic("semaphore: released more than held")
+	}
+	s.notifyWaiters()
+	s.mu.Unlock()
+}
+
+func (s *Weighted) notifyWaiters() {
+	for {
+		next := s.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+
+		w := next.Value.(waiter)
+		if s.size-s.cur < w.n {
+			// Not enough tokens for the next waiter.  We could keep going (to try to
+			// find a waiter with a smaller request), but under load that could cause
+			// starvation for large requests; instead, we leave all remaining waiters
+			// blocked.
+			//
+			// Consider a semaphore used as a read-write lock, with N tokens, N
+			// readers, and one writer.  Each reader can Acquire(1) to obtain a read
+			// lock.  The writer can Acquire(N) to obtain a write lock, excluding all
+			// of the readers.  If we allow the readers to jump ahead in the queue,
+			// the writer will starve — there is always one token available for every
+			// reader.
+			break
+		}
+
+		s.cur += w.n
+		s.waiters.Remove(next)
+		close(w.ready)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -99,10 +99,10 @@ github.com/hashicorp/hcl/v2
 ## explicit; go 1.14
 github.com/hashicorp/terraform/dag
 github.com/hashicorp/terraform/tfdiags
-# github.com/inngest/expr v0.0.0-20240521153320-6f549d6745fd
+# github.com/inngest/expr v0.0.0-20240717151033-03e4378c436c
 ## explicit; go 1.21.0
 github.com/inngest/expr
-# github.com/inngest/inngest v0.29.4-0.20240715161914-8a28f85fdcdc
+# github.com/inngest/inngest v0.29.4-0.20240726163936-6b26ad286424
 ## explicit; go 1.21.0
 github.com/inngest/inngest/pkg/consts
 github.com/inngest/inngest/pkg/dateutil
@@ -329,6 +329,7 @@ golang.org/x/net/trace
 # golang.org/x/sync v0.7.0
 ## explicit; go 1.18
 golang.org/x/sync/errgroup
+golang.org/x/sync/semaphore
 # golang.org/x/sys v0.19.0
 ## explicit; go 1.18
 golang.org/x/sys/plan9


### PR DESCRIPTION
Add a "trust probe". This probe can be used to establish trust between an Inngest server and an SDK.

The probe has a simple purpose: send a signed response back to an Inngest server. The Inngest server can validate the response signature to guarantee that the SDK has the correct signing key