### PR TITLE
Apply JCS before signature validation

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -2,5 +2,5 @@ package inngestgo
 
 const (
 	SDKLanguage = "go"
-	SDKVersion  = "0.5.4"
+	SDKVersion  = "0.7.3"
 )

--- a/examples/main.go
+++ b/examples/main.go
@@ -14,9 +14,7 @@ import (
 )
 
 func main() {
-	h := inngestgo.NewHandler("billing", inngestgo.HandlerOpts{
-		RegisterURL: inngestgo.StrPtr("http://localhost:8090/fn/register"),
-	})
+	h := inngestgo.NewHandler("billing", inngestgo.HandlerOpts{})
 
 	// CreateFunction is a factory method which creates new Inngest functions (step functions,
 	// or workflows) with a specific configuration.
@@ -24,7 +22,7 @@ func main() {
 		inngestgo.FunctionOpts{
 			ID:      "account-created",
 			Name:    "Account creation flow",
-			Retries: inngestgo.IntPtr(0),
+			Retries: inngestgo.IntPtr(5),
 		},
 		// Run on every api/account.created event.
 		inngestgo.EventTrigger("api/account.created", nil),
@@ -46,7 +44,6 @@ func main() {
 // Function state is automatically managed, and persists across server restarts,
 // cloud migrations, and language changes.
 func AccountCreated(ctx context.Context, input inngestgo.Input[AccountCreatedEvent]) (any, error) {
-	return nil, nil
 	// Sleep for a second, minute, hour, week across server restarts.
 	step.Sleep(ctx, "initial-delay", time.Second)
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -14,7 +14,9 @@ import (
 )
 
 func main() {
-	h := inngestgo.NewHandler("billing", inngestgo.HandlerOpts{})
+	h := inngestgo.NewHandler("billing", inngestgo.HandlerOpts{
+		RegisterURL: inngestgo.StrPtr("http://localhost:8090/fn/register"),
+	})
 
 	// CreateFunction is a factory method which creates new Inngest functions (step functions,
 	// or workflows) with a specific configuration.
@@ -22,7 +24,7 @@ func main() {
 		inngestgo.FunctionOpts{
 			ID:      "account-created",
 			Name:    "Account creation flow",
-			Retries: inngestgo.IntPtr(5),
+			Retries: inngestgo.IntPtr(0),
 		},
 		// Run on every api/account.created event.
 		inngestgo.EventTrigger("api/account.created", nil),
@@ -44,6 +46,7 @@ func main() {
 // Function state is automatically managed, and persists across server restarts,
 // cloud migrations, and language changes.
 func AccountCreated(ctx context.Context, input inngestgo.Input[AccountCreatedEvent]) (any, error) {
+	return nil, nil
 	// Sleep for a second, minute, hour, week across server restarts.
 	step.Sleep(ctx, "initial-delay", time.Second)
 

--- a/handler.go
+++ b/handler.go
@@ -774,7 +774,13 @@ func (h *handler) trust(
 		return
 	}
 
-	w.Header().Add("X-Inngest-Signature", Sign(ctx, time.Now(), []byte(key), byt))
+	resSig, err := Sign(ctx, time.Now(), []byte(key), byt)
+	if err != nil {
+		_ = publicerr.WriteHTTP(w, err)
+		return
+	}
+
+	w.Header().Add("X-Inngest-Signature", resSig)
 	w.WriteHeader(200)
 	_, err = w.Write(byt)
 	if err != nil {

--- a/handler_test.go
+++ b/handler_test.go
@@ -494,7 +494,7 @@ func TestIntrospection(t *testing.T) {
 		r := require.New(t)
 
 		reqBody := []byte("")
-		sig := Sign(context.Background(), time.Now(), []byte(testKey), reqBody)
+		sig, _ := Sign(context.Background(), time.Now(), []byte(testKey), reqBody)
 		req, err := http.NewRequest(http.MethodGet, server.URL, bytes.NewReader(reqBody))
 		r.NoError(err)
 		req.Header.Set("X-Inngest-Signature", sig)
@@ -531,7 +531,7 @@ func TestIntrospection(t *testing.T) {
 
 		reqBody := []byte("")
 		invalidKey := "deadbeef"
-		sig := Sign(context.Background(), time.Now(), []byte(invalidKey), reqBody)
+		sig, _ := Sign(context.Background(), time.Now(), []byte(invalidKey), reqBody)
 		req, err := http.NewRequest(http.MethodGet, server.URL, bytes.NewReader(reqBody))
 		r.NoError(err)
 		req.Header.Set("X-Inngest-Signature", sig)
@@ -591,7 +591,7 @@ func handlerPost(t *testing.T, url string, r *sdkrequest.Request) *http.Response
 	t.Helper()
 
 	body := marshalRequest(t, r)
-	sig := Sign(context.Background(), time.Now(), []byte(testKey), body)
+	sig, _ := Sign(context.Background(), time.Now(), []byte(testKey), body)
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 	require.NoError(t, err)

--- a/signature.go
+++ b/signature.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gowebpki/jcs"
+	"github.com/inngest/inngest/pkg/logger"
 )
 
 var (
@@ -27,9 +28,12 @@ var (
 func Sign(ctx context.Context, at time.Time, key, body []byte) (string, error) {
 	key = normalizeKey(key)
 
-	body, err := jcs.Transform(body)
-	if err != nil {
-		return "", fmt.Errorf("failed to canonicalize body: %w", err)
+	var err error
+	if len(body) > 0 {
+		body, err = jcs.Transform(body)
+		if err != nil {
+			logger.StdlibLogger(ctx).Warn("failed to canonicalize body", "error", err)
+		}
 	}
 
 	ts := at.Unix()

--- a/signature_test.go
+++ b/signature_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	testBody        = []byte(`hey!  if you're reading this come work with us: careers@inngest.com`)
+	testBody        = []byte(`{"msg": "hey!  if you're reading this come work with us: careers@inngest.com"}`)
 	testKey         = "signkey-test-12345678"
 	testKeyFallback = "signkey-test-00000000"
 )

--- a/signature_test.go
+++ b/signature_test.go
@@ -23,9 +23,9 @@ func TestSign(t *testing.T) {
 		keyA := []byte("signkey-test-12345678")
 		keyB := []byte("signkey-prod-12345678")
 		keyC := []byte("12345678")
-		a := Sign(ctx, at, keyA, testBody)
-		b := Sign(ctx, at, keyB, testBody)
-		c := Sign(ctx, at, keyC, testBody)
+		a, _ := Sign(ctx, at, keyA, testBody)
+		b, _ := Sign(ctx, at, keyB, testBody)
+		c, _ := Sign(ctx, at, keyC, testBody)
 		require.Equal(t, a, b)
 		require.Equal(t, a, c)
 	})
@@ -54,7 +54,7 @@ func TestValidateSignature(t *testing.T) {
 
 		t.Run("with the wrong key it fails", func(t *testing.T) {
 			at := time.Now()
-			sig := Sign(ctx, at, []byte(testKey), testBody)
+			sig, _ := Sign(ctx, at, []byte(testKey), testBody)
 
 			ok, _, err := ValidateSignature(ctx, sig, "signkey-test-lolwtf", "", testBody)
 			require.False(t, ok)
@@ -64,7 +64,7 @@ func TestValidateSignature(t *testing.T) {
 
 	t.Run("with the same key and within a reasonable time it succeeds", func(t *testing.T) {
 		at := time.Now().Add(-5 * time.Second)
-		sig := Sign(ctx, at, []byte(testKey), testBody)
+		sig, _ := Sign(ctx, at, []byte(testKey), testBody)
 
 		ok, _, err := ValidateSignature(ctx, sig, testKey, "", testBody)
 		require.True(t, ok)


### PR DESCRIPTION
Fix signature validation errors by applying JCS before signature validation. Sometimes the request body has escape sequences (e.g. `\u0026` instead of `&`) that weren't present when Inngest Cloud created the signature