### PR TITLE
Add AllowInBandSync handler option

### DIFF
--- a/env.go
+++ b/env.go
@@ -36,21 +36,11 @@ func DevServerURL() string {
 	return devServerURL
 }
 
-func allowInBandSync() bool {
-	val := os.Getenv(envKeyAllowInBandSync)
-	if val == "" {
-		// TODO: Default to true once in-band syncing is stable
-		return false
-	}
-
-	return isTruthy(val)
-}
-
-func isTruthy(val string) bool {
+func isTrue(val string) bool {
 	val = strings.ToLower(val)
-	if val == "false" || val == "0" || val == "" {
-		return false
+	if val == "true" || val == "1" {
+		return true
 	}
 
-	return true
+	return false
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -555,9 +555,6 @@ func TestIntrospection(t *testing.T) {
 }
 
 func TestInBandSync(t *testing.T) {
-	os.Setenv(envKeyAllowInBandSync, "1")
-	defer os.Unsetenv(envKeyAllowInBandSync)
-
 	appID := "test-in-band-sync"
 
 	fn := CreateFunction(
@@ -568,7 +565,8 @@ func TestInBandSync(t *testing.T) {
 		},
 	)
 	h := NewHandler(appID, HandlerOpts{
-		Env: toPtr("my-env"),
+		AllowInBandSync: toPtr(true),
+		Env:             toPtr("my-env"),
 	})
 	h.Register(fn)
 	server := httptest.NewServer(h)


### PR DESCRIPTION
Add `HandlerOpts.AllowInBandSync` to control whether in-band syncs are allowed.

This is necessary because only using an env var (`INNGEST_ALLOW_IN_BAND_SYNC`) makes tests really hard to write, since env vars aren't scoped to individual tests.