### PR TITLE
Fix trust probe status code

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -9,6 +9,8 @@ import (
 	"github.com/inngest/inngest/pkg/inngest"
 )
 
+func BoolPtr(b bool) *bool { return &b }
+
 func StrPtr(i string) *string { return &i }
 
 func IntPtr(i int) *int { return &i }

--- a/signature.go
+++ b/signature.go
@@ -110,11 +110,12 @@ func ValidateRequestSignature(
 	signingKey string,
 	signingKeyFallback string,
 	body []byte,
+	isDev bool,
 ) (bool, string, error) {
 	// The key that was used to sign the request
 	correctKey := ""
 
-	if IsDev() {
+	if isDev {
 		return true, correctKey, nil
 	}
 

--- a/signature_test.go
+++ b/signature_test.go
@@ -35,21 +35,22 @@ func TestSign(t *testing.T) {
 
 func TestValidateRequestSignature(t *testing.T) {
 	ctx := context.Background()
+	isDev := false
 
 	t.Run("failures", func(t *testing.T) {
 		t.Run("With an invalid sig it fails", func(t *testing.T) {
-			ok, _, err := ValidateRequestSignature(ctx, "lol", testKey, "", testBody)
+			ok, _, err := ValidateRequestSignature(ctx, "lol", testKey, "", testBody, isDev)
 			require.False(t, ok)
 			require.ErrorContains(t, err, "invalid signature")
 		})
 		t.Run("With an invalid ts it fails", func(t *testing.T) {
-			ok, _, err := ValidateRequestSignature(ctx, "t=what&s=yea", testKey, "", testBody)
+			ok, _, err := ValidateRequestSignature(ctx, "t=what&s=yea", testKey, "", testBody, isDev)
 			require.False(t, ok)
 			require.ErrorContains(t, err, "invalid timestamp")
 		})
 		t.Run("With an expired ts it fails", func(t *testing.T) {
 			ts := time.Now().Add(-1 * time.Hour).Unix()
-			ok, _, err := ValidateRequestSignature(ctx, fmt.Sprintf("t=%d&s=yea", ts), testKey, "", testBody)
+			ok, _, err := ValidateRequestSignature(ctx, fmt.Sprintf("t=%d&s=yea", ts), testKey, "", testBody, isDev)
 			require.False(t, ok)
 			require.ErrorContains(t, err, "expired signature")
 		})
@@ -58,7 +59,7 @@ func TestValidateRequestSignature(t *testing.T) {
 			at := time.Now()
 			sig, _ := Sign(ctx, at, []byte(testKey), testBody)
 
-			ok, _, err := ValidateRequestSignature(ctx, sig, "signkey-test-lolwtf", "", testBody)
+			ok, _, err := ValidateRequestSignature(ctx, sig, "signkey-test-lolwtf", "", testBody, isDev)
 			require.False(t, ok)
 			require.ErrorContains(t, err, "invalid signature")
 		})
@@ -68,7 +69,7 @@ func TestValidateRequestSignature(t *testing.T) {
 		at := time.Now().Add(-5 * time.Second)
 		sig, _ := Sign(ctx, at, []byte(testKey), testBody)
 
-		ok, _, err := ValidateRequestSignature(ctx, sig, testKey, "", testBody)
+		ok, _, err := ValidateRequestSignature(ctx, sig, testKey, "", testBody, isDev)
 		require.True(t, ok)
 		require.NoError(t, err)
 	})

--- a/tests/probe_test.go
+++ b/tests/probe_test.go
@@ -1,0 +1,184 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngestgo"
+	"github.com/stretchr/testify/require"
+)
+
+const sKey = "signkey-prod-000000"
+
+func TestTrustProbe(t *testing.T) {
+	t.Run("dev mode", func(t *testing.T) {
+		isDev := true
+
+		t.Run("valid signature", func(t *testing.T) {
+			r := require.New(t)
+			ctx := context.Background()
+
+			appName := randomSuffix("TestTrustProbe")
+			server := createApp(t, appName, isDev)
+			defer server.Close()
+
+			appURL := fmt.Sprintf("%s?probe=trust", server.URL)
+			req, err := http.NewRequest("POST", appURL, nil)
+			r.NoError(err)
+
+			reqSig, err := inngestgo.Sign(ctx, time.Now(), []byte(sKey), []byte{})
+			r.NoError(err)
+			req.Header.Add("x-inngest-signature", reqSig)
+
+			resp, err := http.DefaultClient.Do(req)
+			r.NoError(err)
+			r.Equal(http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("no signature", func(t *testing.T) {
+			r := require.New(t)
+
+			appName := randomSuffix("TestTrustProbe")
+			server := createApp(t, appName, isDev)
+			defer server.Close()
+
+			appURL := fmt.Sprintf("%s?probe=trust", server.URL)
+			req, err := http.NewRequest("POST", appURL, nil)
+			r.NoError(err)
+
+			resp, err := http.DefaultClient.Do(req)
+			r.NoError(err)
+			r.Equal(http.StatusOK, resp.StatusCode)
+		})
+
+		t.Run("invalid signature", func(t *testing.T) {
+			r := require.New(t)
+			ctx := context.Background()
+
+			appName := randomSuffix("TestTrustProbe")
+			server := createApp(t, appName, isDev)
+			defer server.Close()
+
+			appURL := fmt.Sprintf("%s?probe=trust", server.URL)
+			req, err := http.NewRequest("POST", appURL, nil)
+			r.NoError(err)
+
+			wrongSKey := []byte("deadbeef")
+			reqSig, err := inngestgo.Sign(ctx, time.Now(), wrongSKey, []byte{})
+			r.NoError(err)
+			req.Header.Add("x-inngest-signature", reqSig)
+
+			resp, err := http.DefaultClient.Do(req)
+			r.NoError(err)
+			r.Equal(http.StatusOK, resp.StatusCode)
+		})
+	})
+
+	t.Run("cloud mode", func(t *testing.T) {
+		isDev := false
+
+		t.Run("valid signature", func(t *testing.T) {
+			r := require.New(t)
+			ctx := context.Background()
+
+			appName := randomSuffix("TestTrustProbe")
+			server := createApp(t, appName, isDev)
+			defer server.Close()
+
+			appURL := fmt.Sprintf("%s?probe=trust", server.URL)
+			req, err := http.NewRequest("POST", appURL, nil)
+			r.NoError(err)
+
+			reqSig, err := inngestgo.Sign(ctx, time.Now(), []byte(sKey), []byte{})
+			r.NoError(err)
+			req.Header.Add("x-inngest-signature", reqSig)
+
+			resp, err := http.DefaultClient.Do(req)
+			r.NoError(err)
+
+			r.Equal(http.StatusOK, resp.StatusCode)
+
+			respSig := resp.Header.Get("x-inngest-signature")
+			r.NotEmpty(respSig)
+			defer resp.Body.Close()
+
+			respBody, err := io.ReadAll(resp.Body)
+			r.NoError(err)
+
+			valid, err := inngestgo.ValidateResponseSignature(
+				ctx,
+				respSig,
+				[]byte(sKey),
+				respBody,
+			)
+			r.NoError(err)
+			r.True(valid)
+		})
+
+		t.Run("no signature", func(t *testing.T) {
+			r := require.New(t)
+
+			appName := randomSuffix("TestTrustProbe")
+			server := createApp(t, appName, isDev)
+			defer server.Close()
+
+			appURL := fmt.Sprintf("%s?probe=trust", server.URL)
+			req, err := http.NewRequest("POST", appURL, nil)
+			r.NoError(err)
+
+			resp, err := http.DefaultClient.Do(req)
+			r.NoError(err)
+			r.Equal(http.StatusUnauthorized, resp.StatusCode)
+		})
+
+		t.Run("invalid signature", func(t *testing.T) {
+			r := require.New(t)
+			ctx := context.Background()
+
+			appName := randomSuffix("TestTrustProbe")
+			server := createApp(t, appName, isDev)
+			defer server.Close()
+
+			appURL := fmt.Sprintf("%s?probe=trust", server.URL)
+			req, err := http.NewRequest("POST", appURL, nil)
+			r.NoError(err)
+
+			wrongSKey := []byte("deadbeef")
+			reqSig, err := inngestgo.Sign(ctx, time.Now(), wrongSKey, []byte{})
+			r.NoError(err)
+			req.Header.Add("x-inngest-signature", reqSig)
+
+			resp, err := http.DefaultClient.Do(req)
+			r.NoError(err)
+			r.Equal(http.StatusUnauthorized, resp.StatusCode)
+		})
+	})
+}
+
+func createApp(t *testing.T, appName string, isDev bool) *httptest.Server {
+	h := inngestgo.NewHandler(
+		appName,
+		inngestgo.HandlerOpts{
+			Dev:        inngestgo.BoolPtr(isDev),
+			SigningKey: inngestgo.StrPtr(sKey),
+		},
+	)
+	h.Register(inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{
+			ID:   "my-fn",
+			Name: "my-fn",
+		},
+		inngestgo.EventTrigger("my-event", nil),
+		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+			return nil, nil
+		},
+	))
+
+	server, _ := serve(t, h)
+	return server
+}


### PR DESCRIPTION
## Description
- Fix trust probe not setting a response status code in certain failure scenarios.
- Add `HandlerOpts.Dev`, which controls whether the SDK is in "dev mode" (taking precedence over `INNGEST_DEV`). This is necessary for testing, since env vars bleed between tests.
- Fix introspection not responding with the correct data when in "dev mode" and an invalid signature is sent.