### PR TITLE
INN-4047: Convert timeout duration types to strings for

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -57,6 +57,14 @@ func (f FunctionOpts) GetRateLimit() *inngest.RateLimit {
 	return f.RateLimit.Convert()
 }
 
+// GetTimeouts returns the inngest.Timeouts in a compatible type signature.
+func (f FunctionOpts) GetTimeouts() *inngest.Timeouts {
+	if f.Timeouts == nil {
+		return nil
+	}
+	return f.Timeouts.Convert()
+}
+
 // Debounce represents debounce configuration used when creating a new function within
 // FunctionOpts
 type Debounce struct {
@@ -122,7 +130,7 @@ type Timeouts struct {
 	// this is inclusive of time between retries.
 	//
 	// A function may exceed this duration because of concurrency limits, throttling, etc.
-	Start time.Duration `json:"start,omitempty"`
+	Start *time.Duration `json:"start,omitempty"`
 
 	// Finish represents the time between a function starting and the function finishing.
 	// If a function takes longer than this time to finish, the function is marked as cancelled.
@@ -131,7 +139,23 @@ type Timeouts struct {
 	//
 	// Note that if the final request to a function begins before this timeout, and completes
 	// after this timeout, the function will succeed.
-	Finish time.Duration `json:"finish,omitempty"`
+	Finish *time.Duration `json:"finish,omitempty"`
+}
+
+func (t Timeouts) Convert() *inngest.Timeouts {
+	var start, finish *string
+	if t.Start != nil {
+		s := t.Start.String()
+		start = &s
+	}
+	if t.Finish != nil {
+		f := t.Finish.String()
+		finish = &f
+	}
+	return &inngest.Timeouts{
+		Start:  start,
+		Finish: finish,
+	}
 }
 
 // CreateFunction creates a new function which can be registered within a handler.

--- a/handler.go
+++ b/handler.go
@@ -670,7 +670,7 @@ func createFunctionConfigs(
 			Triggers:    inngest.MultipleTriggers{},
 			RateLimit:   fn.Config().GetRateLimit(),
 			Cancel:      fn.Config().Cancel,
-			Timeouts:    (*inngest.Timeouts)(fn.Config().Timeouts),
+			Timeouts:    fn.Config().GetTimeouts(),
 			Throttle:    (*inngest.Throttle)(fn.Config().Throttle),
 			Steps: map[string]sdk.SDKStep{
 				"step": {

--- a/vendor/github.com/inngest/inngest/pkg/inngest/function.go
+++ b/vendor/github.com/inngest/inngest/pkg/inngest/function.go
@@ -200,7 +200,7 @@ type Timeouts struct {
 	// this is inclusive of time between retries.
 	//
 	// A function may exceed this duration because of concurrency limits, throttling, etc.
-	Start time.Duration `json:"start"`
+	Start *string `json:"start,omitempty"`
 
 	// Finish represents the time between a function starting and the function finishing.
 	// If a function takes longer than this time to finish, the function is marked as cancelled.
@@ -209,7 +209,27 @@ type Timeouts struct {
 	//
 	// Note that if the final request to a function begins before this timeout, and completes
 	// after this timeout, the function will succeed.
-	Finish time.Duration `json:"finish"`
+	Finish *string `json:"finish,omitempty"`
+}
+
+func (t Timeouts) StartDuration() *time.Duration {
+	if t.Start == nil || *t.Start == "" {
+		return nil
+	}
+	if dur, err := str2duration.ParseDuration(*t.Start); err == nil {
+		return &dur
+	}
+	return nil
+}
+
+func (t Timeouts) FinishDuration() *time.Duration {
+	if t.Finish == nil || *t.Finish == "" {
+		return nil
+	}
+	if dur, err := str2duration.ParseDuration(*t.Finish); err == nil {
+		return &dur
+	}
+	return nil
 }
 
 type Priority struct {


### PR DESCRIPTION
Upstream vendor changes from: https://github.com/inngest/inngest/pull/1968

### Related
INN-4047
https://github.com/inngest/inngest/issues/1967
