### PR TITLE
Generate consistent function slug

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -70,7 +70,7 @@ func (h *handler) getServableFunctionBySlug(slug string) ServableFunction {
 	h.l.RLock()
 	var fn ServableFunction
 	for _, f := range h.funcs {
-		if f.Slug() == slug {
+		if f.Slug(h.appName) == slug {
 			fn = f
 			break
 		}

--- a/funcs.go
+++ b/funcs.go
@@ -238,7 +238,7 @@ type SDKFunction[T any] func(ctx context.Context, input Input[T]) (any, error)
 // This is created via CreateFunction in this package.
 type ServableFunction interface {
 	// Slug returns the function's human-readable ID, such as "sign-up-flow".
-	Slug() string
+	Slug(appName string) string
 
 	// Name returns the function name.
 	Name() string
@@ -284,11 +284,19 @@ func (s servableFunc) Config() FunctionOpts {
 	return s.fc
 }
 
-func (s servableFunc) Slug() string {
-	if s.fc.ID == "" {
-		return slug.Make(s.fc.Name)
+func (s servableFunc) Slug(appName string) string {
+	fnSlug := s.fc.ID
+	if fnSlug == "" {
+		fnSlug = slug.Make(s.fc.Name)
 	}
-	return s.fc.ID
+
+	// Old format which only includes the fn slug
+	// This should no longer be used.
+	if appName == "" {
+		return fnSlug
+	}
+
+	return appName + "-" + fnSlug
 }
 
 func (s servableFunc) Name() string {

--- a/handler_test.go
+++ b/handler_test.go
@@ -334,7 +334,10 @@ func TestServe(t *testing.T) {
 
 	t.Run("It calls the correct function with the correct data", func(t *testing.T) {
 		queryParams := url.Values{}
-		queryParams.Add("fnId", a.Slug())
+		appName := "Go app"
+		DefaultHandler.SetAppName(appName)
+
+		queryParams.Add("fnId", a.Slug(appName))
 
 		url := fmt.Sprintf("%s?%s", server.URL, queryParams.Encode())
 		resp := handlerPost(t, url, createRequest(t, event))
@@ -402,8 +405,11 @@ func TestSteps(t *testing.T) {
 
 	Register(a)
 	server := httptest.NewServer(DefaultHandler)
+	appName := "Go app"
+	DefaultHandler.SetAppName(appName)
+
 	queryParams := url.Values{}
-	queryParams.Add("fnId", a.Slug())
+	queryParams.Add("fnId", a.Slug(appName))
 	url := fmt.Sprintf("%s?%s", server.URL, queryParams.Encode())
 
 	t.Run("It invokes the first step and returns an opcode", func(t *testing.T) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -795,7 +795,7 @@ func TestInBandSync(t *testing.T) {
 							ID:   "step",
 							Name: "my-fn",
 							Runtime: map[string]any{
-								"url": "http://test.local?fnId=my-fn&step=step",
+								"url": fmt.Sprintf("http://test.local?fnId=%s-my-fn&step=step", appID),
 							},
 						},
 					},


### PR DESCRIPTION
Previously, we did not include the app name (app slug) in the step runtime URL, as we do in the JS and Python SDK.

This changed to always use the _full_ function ID.

This also adds graceful handling for executor requests using the old function config (i.e. requests with `fnId` query parameter that is _only_ the function ID without the app name prefix), so that requests continue to work during a deployment (before the new config is synced).