### PR TITLE
Make event key optional in dev

### DIFF
--- a/client.go
+++ b/client.go
@@ -98,10 +98,20 @@ func (a apiClient) GetEnv() string {
 }
 
 func (a apiClient) GetEventKey() string {
-	if a.EventKey == nil {
-		return os.Getenv("INNGEST_EVENT_KEY")
+	if a.EventKey != nil {
+		return *a.EventKey
 	}
-	return *a.EventKey
+
+	envVar := os.Getenv("INNGEST_EVENT_KEY")
+	if envVar != "" {
+		return envVar
+	}
+
+	if IsDev() {
+		return "NO_EVENT_KEY_SET"
+	}
+
+	return ""
 }
 
 type validatable interface {

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,44 @@
+package inngestgo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEventKey(t *testing.T) {
+	t.Run("env var", func(t *testing.T) {
+		c := apiClient{}
+		t.Setenv("INNGEST_EVENT_KEY", "env-var")
+		assert.Equal(t, "env-var", c.GetEventKey())
+	})
+
+	t.Run("field", func(t *testing.T) {
+		c := apiClient{
+			ClientOpts: ClientOpts{
+				EventKey: StrPtr("field"),
+			},
+		}
+		assert.Equal(t, "field", c.GetEventKey())
+	})
+
+	t.Run("field overrides env var", func(t *testing.T) {
+		t.Setenv("INNGEST_EVENT_KEY", "env-var")
+		c := apiClient{
+			ClientOpts: ClientOpts{EventKey: StrPtr("field")},
+		}
+		assert.Equal(t, "field", c.GetEventKey())
+	})
+
+	t.Run("no event key in Cloud mode", func(t *testing.T) {
+		// t.Setenv("INNGEST_EVENT_KEY", "")
+		c := apiClient{}
+		assert.Equal(t, "", c.GetEventKey())
+	})
+
+	t.Run("no event key in Dev mode", func(t *testing.T) {
+		t.Setenv("INNGEST_DEV", "1")
+		c := apiClient{}
+		assert.Equal(t, "NO_EVENT_KEY_SET", c.GetEventKey())
+	})
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -25,10 +24,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func init() {
-	os.Setenv("INNGEST_EVENT_KEY", "abc123")
-	os.Setenv("INNGEST_SIGNING_KEY", string(testKey))
-	os.Setenv("INNGEST_SIGNING_KEY_FALLBACK", string(testKeyFallback))
+func setEnvVars(t *testing.T) {
+	t.Setenv("INNGEST_EVENT_KEY", "abc123")
+	t.Setenv("INNGEST_SIGNING_KEY", string(testKey))
+	t.Setenv("INNGEST_SIGNING_KEY_FALLBACK", string(testKeyFallback))
 }
 
 type EventA struct {
@@ -43,6 +42,8 @@ type EventB struct{}
 type EventC struct{}
 
 func TestRegister(t *testing.T) {
+	setEnvVars(t)
+
 	a := CreateFunction(
 		FunctionOpts{
 			Name: "my func name",
@@ -299,6 +300,8 @@ func TestInvoke(t *testing.T) {
 }
 
 func TestServe(t *testing.T) {
+	setEnvVars(t)
+
 	event := EventA{
 		Name: "test/event.a",
 		Data: struct {
@@ -368,6 +371,8 @@ func TestServe(t *testing.T) {
 }
 
 func TestSteps(t *testing.T) {
+	setEnvVars(t)
+
 	event := EventA{
 		Name: "test/event.a",
 		Data: struct {
@@ -488,6 +493,8 @@ func TestSteps(t *testing.T) {
 }
 
 func TestInspection(t *testing.T) {
+	setEnvVars(t)
+
 	t.Run("dev mode", func(t *testing.T) {
 		fn := CreateFunction(
 			FunctionOpts{Name: "My servable function!"},
@@ -738,6 +745,7 @@ func TestInspection(t *testing.T) {
 }
 
 func TestInBandSync(t *testing.T) {
+	setEnvVars(t)
 	appID := "test-in-band-sync"
 
 	fn := CreateFunction(


### PR DESCRIPTION
Before these changes, events would fail to send when `INNGEST_DEV=1` because the event key wasn't set. This shouldn't be the behavior since the Dev Server doesn't require event keys