### PR TITLE
Wait for shutdown, expose too many connections error

### DIFF
--- a/connect/handler.go
+++ b/connect/handler.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"sync/atomic"
 	"time"
 )
 
@@ -142,6 +143,7 @@ type connectHandler struct {
 	cancelWorkerCtx context.CancelFunc
 	eg              errgroup.Group
 	auth            authContext
+	closed          atomic.Bool
 }
 
 // authContext is wrapper for information related to authentication
@@ -194,8 +196,8 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 	// Instead of doing a simple, synchronous loop, we use channels to communicate connection status changes,
 	// allowing to instantiate a new connection while the previous one is still running.
 	// This is crucial for handling gateway draining scenarios.
-	h.eg = errgroup.Group{}
-	h.eg.Go(func() error {
+	runLoop := errgroup.Group{}
+	runLoop.Go(func() error {
 		for {
 			select {
 			// If the context is canceled, we should not attempt to reconnect
@@ -336,8 +338,9 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 	})
 
 	// Handle run loop closure gracefully, this is also triggered on Close()
-	go func() {
-		runLoopErr := h.eg.Wait()
+	h.eg = errgroup.Group{}
+	h.eg.Go(func() error {
+		runLoopErr := runLoop.Wait()
 		if runLoopErr != nil {
 			h.logger.Error("could not connect", "err", runLoopErr)
 		}
@@ -364,7 +367,8 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 		}
 
 		h.logger.Debug("connect handler done")
-	}()
+		return nil
+	})
 
 	// Initiate the first connection
 	h.initiateConnectionChan <- struct{}{}
@@ -385,6 +389,11 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 }
 
 func (h *connectHandler) Close() error {
+	// If connection was already closed, this is a no-op.
+	if h.closed.Swap(true) {
+		return nil
+	}
+
 	if h.cancelWorkerCtx == nil {
 		return fmt.Errorf("connection was not fully set up")
 	}
@@ -396,6 +405,8 @@ func (h *connectHandler) Close() error {
 	if err != nil {
 		return fmt.Errorf("failed to connect: %w", err)
 	}
+
+	h.state = ConnectionStateClosed
 
 	return nil
 }

--- a/connect/handshake.go
+++ b/connect/handshake.go
@@ -36,6 +36,7 @@ func shouldReconnect(err error) bool {
 }
 
 var ErrUnauthenticated = fmt.Errorf("authentication failed")
+var ErrTooManyConnections = fmt.Errorf("too many connections")
 
 func (h *connectHandler) performConnectHandshake(ctx context.Context, connectionId string, ws *websocket.Conn, startResponse *connectproto.StartResponse, data connectionEstablishData, startTime time.Time) error {
 	// Wait for gateway hello message

--- a/connect/workerapi.go
+++ b/connect/workerapi.go
@@ -56,6 +56,10 @@ func (a *workerApiClient) start(ctx context.Context, hashedSigningKey []byte, re
 			return nil, newReconnectErr(ErrUnauthenticated)
 		}
 
+		if httpRes.StatusCode == http.StatusTooManyRequests {
+			return nil, newReconnectErr(ErrTooManyConnections)
+		}
+
 		byt, err := io.ReadAll(httpRes.Body)
 		if err != nil {
 			return nil, fmt.Errorf("could not read start error: %w", err)


### PR DESCRIPTION
- `conn.Close()` now only runs once and waits for the connection shutdown to complete before returning
-  `Connect()` will return an error if the connection limit is exceeded during the first connection