### PR TITLE
Add step.Send and step.SendMany

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -145,7 +145,7 @@ func (h *handler) InvokeFunction(ctx context.Context, slug string, stepId *strin
 	}
 
 	// Invoke function, always complete regardless of
-	resp, ops, err := invoke(context.Background(), fn, h.GetSigningKey(), &request, stepId)
+	resp, ops, err := invoke(context.Background(), h.client, fn, h.GetSigningKey(), &request, stepId)
 
 	return resp, ops, err
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -114,7 +114,7 @@ func TestInvoke(t *testing.T) {
 		r.NoError(err)
 
 		t.Run("it invokes the function with correct types", func(t *testing.T) {
-			actual, op, err := invoke(ctx, a, testKey, createRequest(t, input), nil)
+			actual, op, err := invoke(ctx, c, a, testKey, createRequest(t, input), nil)
 			require.NoError(t, err)
 			require.Nil(t, op)
 			require.Equal(t, resp, actual)
@@ -152,7 +152,7 @@ func TestInvoke(t *testing.T) {
 		r.NoError(err)
 
 		t.Run("it invokes the function with correct types", func(t *testing.T) {
-			actual, op, err := invoke(ctx, a, testKey, createBatchRequest(t, input, 5), nil)
+			actual, op, err := invoke(ctx, c, a, testKey, createBatchRequest(t, input, 5), nil)
 			require.NoError(t, err)
 			require.Nil(t, op)
 			require.Equal(t, resp, actual)
@@ -191,7 +191,7 @@ func TestInvoke(t *testing.T) {
 		ctx := context.Background()
 
 		t.Run("it invokes the function with correct types", func(t *testing.T) {
-			actual, op, err := invoke(ctx, a, testKey, createRequest(t, input), nil)
+			actual, op, err := invoke(ctx, c, a, testKey, createRequest(t, input), nil)
 			require.NoError(t, err)
 			require.Nil(t, op)
 			require.Equal(t, resp, actual)
@@ -233,7 +233,7 @@ func TestInvoke(t *testing.T) {
 
 		ctx := context.Background()
 		t.Run("it invokes the function with correct types", func(t *testing.T) {
-			actual, op, err := invoke(ctx, a, testKey, createRequest(t, input), nil)
+			actual, op, err := invoke(ctx, c, a, testKey, createRequest(t, input), nil)
 			require.NoError(t, err)
 			require.Nil(t, op)
 			require.Equal(t, resp, actual)
@@ -274,7 +274,7 @@ func TestInvoke(t *testing.T) {
 
 		ctx := context.Background()
 		t.Run("it invokes the function with correct types", func(t *testing.T) {
-			actual, op, err := invoke(ctx, a, testKey, createRequest(t, input), nil)
+			actual, op, err := invoke(ctx, c, a, testKey, createRequest(t, input), nil)
 			require.NoError(t, err)
 			require.Nil(t, op)
 			require.Equal(t, resp, actual)
@@ -319,7 +319,7 @@ func TestInvoke(t *testing.T) {
 		r.NoError(err)
 
 		actual, op, err := invoke(
-			ctx, a, testKey,
+			ctx, c, a, testKey,
 			createRequest(t, EventA{Name: "my-event"}),
 			nil,
 		)

--- a/internal/ctx.go
+++ b/internal/ctx.go
@@ -1,0 +1,21 @@
+package internal
+
+import "context"
+
+type eventSenderCtxKeyType struct{}
+
+var eventSenderCtxKey = eventSenderCtxKeyType{}
+
+type eventSender interface {
+	Send(ctx context.Context, evt any) (string, error)
+	SendMany(ctx context.Context, evt []any) ([]string, error)
+}
+
+func ContextWithEventSender(ctx context.Context, sender eventSender) context.Context {
+	return context.WithValue(ctx, eventSenderCtxKey, sender)
+}
+
+func EventSenderFromContext(ctx context.Context) (eventSender, bool) {
+	sender, ok := ctx.Value(eventSenderCtxKey).(eventSender)
+	return sender, ok
+}

--- a/step/send.go
+++ b/step/send.go
@@ -1,0 +1,44 @@
+package step
+
+import (
+	"context"
+	"errors"
+
+	"github.com/inngest/inngestgo/internal"
+)
+
+// Send sends an event to Inngest.
+func Send(
+	ctx context.Context,
+	id string,
+	event internal.Event,
+) (string, error) {
+	return Run(ctx, id, func(ctx context.Context) (string, error) {
+		sender, ok := internal.EventSenderFromContext(ctx)
+		if !ok {
+			return "", errors.New("no event sender found in context")
+		}
+
+		return sender.Send(ctx, event)
+	})
+}
+
+// SendMany sends a batch of events to Inngest.
+func SendMany(
+	ctx context.Context,
+	id string,
+	events []internal.Event,
+) ([]string, error) {
+	return Run(ctx, id, func(ctx context.Context) ([]string, error) {
+		sender, ok := internal.EventSenderFromContext(ctx)
+		if !ok {
+			return nil, errors.New("no event sender found in context")
+		}
+
+		many := make([]any, len(events))
+		for i, event := range events {
+			many[i] = event
+		}
+		return sender.SendMany(ctx, many)
+	})
+}

--- a/tests/invoke_test.go
+++ b/tests/invoke_test.go
@@ -26,7 +26,6 @@ func TestInvoke(t *testing.T) {
 		appName := randomSuffix("my-app")
 		c, err := inngestgo.NewClient(inngestgo.ClientOpts{AppID: appName})
 		r.NoError(err)
-		// h := inngestgo.newHandler(c, inngestgo.handlerOpts{})
 
 		type ChildEventData struct {
 			Message string `json:"message"`

--- a/tests/send_test.go
+++ b/tests/send_test.go
@@ -1,0 +1,260 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngestgo"
+	"github.com/inngest/inngestgo/step"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSend(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	t.Run("success", func(t *testing.T) {
+		ctx := context.Background()
+		r := require.New(t)
+
+		appName := randomSuffix("app")
+		c, err := inngestgo.NewClient(inngestgo.ClientOpts{AppID: appName})
+		r.NoError(err)
+
+		var receivedEventID string
+		childEventName := randomSuffix("child-event")
+		_, err = inngestgo.CreateFunction(
+			c,
+			inngestgo.FunctionOpts{
+				ID:      "child-fn",
+				Retries: inngestgo.IntPtr(0),
+			},
+			inngestgo.EventTrigger(childEventName, nil),
+			func(
+				ctx context.Context,
+				input inngestgo.Input[inngestgo.GenericEvent[any, any]],
+			) (any, error) {
+				receivedEventID = *input.Event.ID
+				return nil, nil
+			},
+		)
+		r.NoError(err)
+
+		var runID string
+		var sentEventID string
+		var sendErr error
+		eventName := randomSuffix("event")
+		_, err = inngestgo.CreateFunction(
+			c,
+			inngestgo.FunctionOpts{
+				ID:      "parent-fn",
+				Retries: inngestgo.IntPtr(0),
+			},
+			inngestgo.EventTrigger(eventName, nil),
+			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+				runID = input.InputCtx.RunID
+				sentEventID, sendErr = step.Send(ctx,
+					"send",
+					inngestgo.Event{Name: childEventName},
+				)
+				return nil, sendErr
+			},
+		)
+		r.NoError(err)
+
+		server, sync := serve(t, c)
+		defer server.Close()
+		r.NoError(sync())
+
+		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
+		r.NoError(err)
+
+		var run *Run
+		r.EventuallyWithT(func(ct *assert.CollectT) {
+			a := assert.New(ct)
+
+			run, err = getRun(runID)
+			if !a.NoError(err) {
+				return
+			}
+
+			a.Equal(enums.RunStatusCompleted.String(), run.Status)
+			a.Equal(sentEventID, receivedEventID)
+			a.NoError(sendErr)
+		}, 5*time.Second, time.Second)
+	})
+	t.Run("error", func(t *testing.T) {
+		ctx := context.Background()
+		r := require.New(t)
+
+		appName := randomSuffix("app")
+		c, err := inngestgo.NewClient(inngestgo.ClientOpts{AppID: appName})
+		r.NoError(err)
+
+		var runID string
+		var sendErr error
+		eventName := randomSuffix("event")
+		_, err = inngestgo.CreateFunction(
+			c,
+			inngestgo.FunctionOpts{
+				ID:      "parent-fn",
+				Retries: inngestgo.IntPtr(0),
+			},
+			inngestgo.EventTrigger(eventName, nil),
+			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+				runID = input.InputCtx.RunID
+				_, sendErr = step.Send(ctx,
+					"send",
+					inngestgo.Event{Name: "inngest/foo"},
+				)
+				return nil, sendErr
+			},
+		)
+		r.NoError(err)
+
+		server, sync := serve(t, c)
+		defer server.Close()
+		r.NoError(sync())
+
+		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
+		r.NoError(err)
+
+		var run *Run
+		r.EventuallyWithT(func(ct *assert.CollectT) {
+			a := assert.New(ct)
+
+			run, err = getRun(runID)
+			if !a.NoError(err) {
+				return
+			}
+
+			a.Equal(enums.RunStatusFailed.String(), run.Status)
+			a.Error(sendErr)
+			a.Equal(
+				"bad request: event name is reserved for internal use: inngest/foo",
+				sendErr.Error(),
+			)
+		}, 5*time.Second, time.Second)
+	})
+}
+
+func TestSendMany(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	t.Run("success", func(t *testing.T) {
+		ctx := context.Background()
+		r := require.New(t)
+
+		appName := randomSuffix("app")
+		c, err := inngestgo.NewClient(inngestgo.ClientOpts{AppID: appName})
+		r.NoError(err)
+
+		var runID string
+		var sentEventIDs []string
+		var sendErr error
+		eventName := randomSuffix("event")
+		_, err = inngestgo.CreateFunction(
+			c,
+			inngestgo.FunctionOpts{
+				ID:      "parent-fn",
+				Retries: inngestgo.IntPtr(0),
+			},
+			inngestgo.EventTrigger(eventName, nil),
+			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+				runID = input.InputCtx.RunID
+				sentEventIDs, sendErr = step.SendMany(ctx,
+					"send",
+					[]inngestgo.Event{
+						{Name: randomSuffix("child-event")},
+						{Name: randomSuffix("child-event")},
+					},
+				)
+				return nil, sendErr
+			},
+		)
+		r.NoError(err)
+
+		server, sync := serve(t, c)
+		defer server.Close()
+		r.NoError(sync())
+
+		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
+		r.NoError(err)
+
+		var run *Run
+		r.EventuallyWithT(func(ct *assert.CollectT) {
+			a := assert.New(ct)
+
+			run, err = getRun(runID)
+			if !a.NoError(err) {
+				return
+			}
+
+			a.Equal(enums.RunStatusCompleted.String(), run.Status)
+			a.Len(sentEventIDs, 2)
+			a.NoError(sendErr)
+		}, 5*time.Second, time.Second)
+	})
+	t.Run("error", func(t *testing.T) {
+		ctx := context.Background()
+		r := require.New(t)
+
+		appName := randomSuffix("app")
+		c, err := inngestgo.NewClient(inngestgo.ClientOpts{AppID: appName})
+		r.NoError(err)
+
+		var runID string
+		var sendErr error
+		eventName := randomSuffix("event")
+		_, err = inngestgo.CreateFunction(
+			c,
+			inngestgo.FunctionOpts{
+				ID:      "parent-fn",
+				Retries: inngestgo.IntPtr(0),
+			},
+			inngestgo.EventTrigger(eventName, nil),
+			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+				runID = input.InputCtx.RunID
+				_, sendErr = step.SendMany(ctx,
+					"send",
+					[]inngestgo.Event{
+						{Name: "inngest/foo"},
+						{Name: "inngest/foo"},
+					},
+				)
+				return nil, sendErr
+			},
+		)
+		r.NoError(err)
+
+		server, sync := serve(t, c)
+		defer server.Close()
+		r.NoError(sync())
+
+		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
+		r.NoError(err)
+
+		var run *Run
+		r.EventuallyWithT(func(ct *assert.CollectT) {
+			a := assert.New(ct)
+
+			run, err = getRun(runID)
+			if !a.NoError(err) {
+				return
+			}
+
+			a.Equal(enums.RunStatusFailed.String(), run.Status)
+			a.Error(sendErr)
+			a.Equal(
+				"bad request: event name is reserved for internal use: inngest/foo",
+				sendErr.Error(),
+			)
+		}, 5*time.Second, time.Second)
+	})
+}


### PR DESCRIPTION
Add `step.Send` and `step.SendMany`. These are the only user-facing changes.

The `Event` struct had to be moved into the `internal` package because we can't import `inngestgo` inside the `inngestgo/step` package (that causes a circular import)