### PR TITLE
Add AfterExecution middleware hook

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+
+	"github.com/inngest/inngestgo/experimental"
 )
 
 const (
@@ -92,6 +94,9 @@ type ClientOpts struct {
 
 	// Dev is whether to use the Dev Server.
 	Dev *bool
+
+	// Middleware is a list of middleware to apply to the client.
+	Middleware []experimental.Middleware
 }
 
 func (c ClientOpts) validate() error {

--- a/connect.go
+++ b/connect.go
@@ -8,6 +8,7 @@ import (
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/publicerr"
 	"github.com/inngest/inngestgo/connect"
+	"github.com/inngest/inngestgo/internal/middleware"
 	"github.com/inngest/inngestgo/internal/sdkrequest"
 )
 
@@ -144,8 +145,21 @@ func (h *handler) InvokeFunction(ctx context.Context, slug string, stepId *strin
 		}
 	}
 
-	// Invoke function, always complete regardless of
-	resp, ops, err := invoke(context.Background(), h.client, fn, h.GetSigningKey(), &request, stepId)
+	cImpl, ok := h.client.(*apiClient)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid client")
+	}
+	mw := middleware.NewMiddlewareManager().Add(cImpl.Middleware...)
 
+	// Invoke function, always complete regardless of
+	resp, ops, err := invoke(
+		context.Background(),
+		h.client,
+		mw,
+		fn,
+		h.GetSigningKey(),
+		&request,
+		stepId,
+	)
 	return resp, ops, err
 }

--- a/experimental/expose_internal.go
+++ b/experimental/expose_internal.go
@@ -1,0 +1,5 @@
+package experimental
+
+import "github.com/inngest/inngestgo/internal/middleware"
+
+type Middleware = middleware.Middleware

--- a/handler_test.go
+++ b/handler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/sdk"
 	"github.com/inngest/inngest/pkg/syscode"
+	"github.com/inngest/inngestgo/internal/middleware"
 	"github.com/inngest/inngestgo/internal/sdkrequest"
 	"github.com/inngest/inngestgo/step"
 	"github.com/stretchr/testify/require"
@@ -83,6 +84,8 @@ func TestRegister(t *testing.T) {
 // TestInvoke asserts that invoking a function with both the correct and incorrect type
 // works as expected.
 func TestInvoke(t *testing.T) {
+	mw := middleware.NewMiddlewareManager()
+
 	t.Run("With a struct value event type", func(t *testing.T) {
 		ctx := context.Background()
 		r := require.New(t)
@@ -114,7 +117,7 @@ func TestInvoke(t *testing.T) {
 		r.NoError(err)
 
 		t.Run("it invokes the function with correct types", func(t *testing.T) {
-			actual, op, err := invoke(ctx, c, a, testKey, createRequest(t, input), nil)
+			actual, op, err := invoke(ctx, c, mw, a, testKey, createRequest(t, input), nil)
 			require.NoError(t, err)
 			require.Nil(t, op)
 			require.Equal(t, resp, actual)
@@ -152,7 +155,7 @@ func TestInvoke(t *testing.T) {
 		r.NoError(err)
 
 		t.Run("it invokes the function with correct types", func(t *testing.T) {
-			actual, op, err := invoke(ctx, c, a, testKey, createBatchRequest(t, input, 5), nil)
+			actual, op, err := invoke(ctx, c, mw, a, testKey, createBatchRequest(t, input, 5), nil)
 			require.NoError(t, err)
 			require.Nil(t, op)
 			require.Equal(t, resp, actual)
@@ -191,7 +194,7 @@ func TestInvoke(t *testing.T) {
 		ctx := context.Background()
 
 		t.Run("it invokes the function with correct types", func(t *testing.T) {
-			actual, op, err := invoke(ctx, c, a, testKey, createRequest(t, input), nil)
+			actual, op, err := invoke(ctx, c, mw, a, testKey, createRequest(t, input), nil)
 			require.NoError(t, err)
 			require.Nil(t, op)
 			require.Equal(t, resp, actual)
@@ -233,7 +236,7 @@ func TestInvoke(t *testing.T) {
 
 		ctx := context.Background()
 		t.Run("it invokes the function with correct types", func(t *testing.T) {
-			actual, op, err := invoke(ctx, c, a, testKey, createRequest(t, input), nil)
+			actual, op, err := invoke(ctx, c, mw, a, testKey, createRequest(t, input), nil)
 			require.NoError(t, err)
 			require.Nil(t, op)
 			require.Equal(t, resp, actual)
@@ -274,7 +277,7 @@ func TestInvoke(t *testing.T) {
 
 		ctx := context.Background()
 		t.Run("it invokes the function with correct types", func(t *testing.T) {
-			actual, op, err := invoke(ctx, c, a, testKey, createRequest(t, input), nil)
+			actual, op, err := invoke(ctx, c, mw, a, testKey, createRequest(t, input), nil)
 			require.NoError(t, err)
 			require.Nil(t, op)
 			require.Equal(t, resp, actual)
@@ -319,7 +322,7 @@ func TestInvoke(t *testing.T) {
 		r.NoError(err)
 
 		actual, op, err := invoke(
-			ctx, c, a, testKey,
+			ctx, c, mw, a, testKey,
 			createRequest(t, EventA{Name: "my-event"}),
 			nil,
 		)

--- a/internal/middleware/manager.go
+++ b/internal/middleware/manager.go
@@ -1,0 +1,29 @@
+package middleware
+
+import "context"
+
+func NewMiddlewareManager() *MiddlewareManager {
+	return &MiddlewareManager{
+		items: []Middleware{},
+	}
+}
+
+// MiddlewareManager is a thin wrapper around middleware, allowing our business
+// logic to be oblivious of how many middlewares exist.
+type MiddlewareManager struct {
+	items []Middleware
+}
+
+// Add adds middleware to the manager.
+func (m *MiddlewareManager) Add(mw ...Middleware) *MiddlewareManager {
+	m.items = append(m.items, mw...)
+	return m
+}
+
+func (m *MiddlewareManager) AfterExecution(ctx context.Context) {
+	for _, mw := range m.items {
+		if mw.AfterExecution != nil {
+			mw.AfterExecution(ctx)
+		}
+	}
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -1,0 +1,9 @@
+package middleware
+
+import "context"
+
+type Middleware struct {
+	// AfterExecution is called after executing "new code". Called multiple
+	// times per run when using steps.
+	AfterExecution func(ctx context.Context)
+}

--- a/tests/middleware_test.go
+++ b/tests/middleware_test.go
@@ -1,0 +1,155 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngestgo"
+	"github.com/inngest/inngestgo/experimental"
+	"github.com/inngest/inngestgo/step"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientMiddleware(t *testing.T) {
+	t.Run("2 steps", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
+
+		logs := []string{}
+		c, err := inngestgo.NewClient(inngestgo.ClientOpts{
+			AppID: randomSuffix("app"),
+			Middleware: []experimental.Middleware{
+				{
+					AfterExecution: func(ctx context.Context) {
+						logs = append(logs, "mw: AfterExecution")
+					},
+				},
+			},
+		})
+		r.NoError(err)
+
+		eventName := randomSuffix("event")
+		_, err = inngestgo.CreateFunction(
+			c,
+			inngestgo.FunctionOpts{
+				ID:      "fn",
+				Retries: inngestgo.IntPtr(0),
+			},
+			inngestgo.EventTrigger(eventName, nil),
+			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+				logs = append(logs, "fn: top")
+
+				_, err := step.Run(ctx, "a", func(ctx context.Context) (any, error) {
+					logs = append(logs, "a: running")
+					return nil, nil
+				})
+				if err != nil {
+					return nil, err
+				}
+
+				logs = append(logs, "fn: between steps")
+
+				_, err = step.Run(ctx, "b", func(ctx context.Context) (any, error) {
+					logs = append(logs, "b: running")
+					return nil, nil
+				})
+
+				logs = append(logs, "fn: bottom")
+				return nil, err
+			},
+		)
+		r.NoError(err)
+
+		server, sync := serve(t, c)
+		defer server.Close()
+		r.NoError(sync())
+
+		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
+		r.NoError(err)
+
+		r.EventuallyWithT(func(ct *assert.CollectT) {
+			a := assert.New(ct)
+			a.Equal([]string{
+				// First request.
+				"fn: top",
+				"a: running",
+				"mw: AfterExecution",
+
+				// Second request.
+				"fn: top",
+				"fn: between steps",
+				"b: running",
+				"mw: AfterExecution",
+
+				// Third request.
+				"fn: top",
+				"fn: between steps",
+				"fn: bottom",
+				"mw: AfterExecution",
+			}, logs)
+		}, 5*time.Second, 10*time.Millisecond)
+	})
+	t.Run("retry", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
+
+		logs := []string{}
+		c, err := inngestgo.NewClient(inngestgo.ClientOpts{
+			AppID: randomSuffix("app"),
+			Middleware: []experimental.Middleware{
+				{
+					AfterExecution: func(ctx context.Context) {
+						logs = append(logs, "mw: AfterExecution")
+					},
+				},
+			},
+		})
+		r.NoError(err)
+
+		eventName := randomSuffix("event")
+		_, err = inngestgo.CreateFunction(
+			c,
+			inngestgo.FunctionOpts{
+				ID:      "fn",
+				Retries: inngestgo.IntPtr(1),
+			},
+			inngestgo.EventTrigger(eventName, nil),
+			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+				logs = append(logs, "fn: top")
+				if input.InputCtx.Attempt == 0 {
+					return nil, inngestgo.RetryAtError(
+						errors.New("oh no"),
+						time.Now().Add(time.Second),
+					)
+				}
+				logs = append(logs, "fn: bottom")
+				return nil, nil
+			},
+		)
+		r.NoError(err)
+
+		server, sync := serve(t, c)
+		defer server.Close()
+		r.NoError(sync())
+
+		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
+		r.NoError(err)
+
+		r.EventuallyWithT(func(ct *assert.CollectT) {
+			a := assert.New(ct)
+			a.Equal([]string{
+				// First request.
+				"fn: top",
+				"mw: AfterExecution",
+
+				// Second request.
+				"fn: top",
+				"fn: bottom",
+				"mw: AfterExecution",
+			}, logs)
+		}, 5*time.Second, 10*time.Millisecond)
+	})
+}


### PR DESCRIPTION
Add the initial scaffolding for middleware, only implementing the `AfterExecution` hook. Subsequent PRs will add more hooks