### PR TITLE
Fix Connect requiring signing key in dev mode

### DIFF
--- a/client.go
+++ b/client.go
@@ -109,6 +109,10 @@ func NewClient(opts ClientOpts) (Client, error) {
 		return nil, err
 	}
 
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+
 	c := &apiClient{
 		ClientOpts: opts,
 	}

--- a/connect.go
+++ b/connect.go
@@ -79,18 +79,21 @@ func Connect(ctx context.Context, opts ConnectOpts) (connect.WorkerConnection, e
 		return nil, fmt.Errorf("invalid handler passed")
 	}
 
+	var hashedKey []byte
+	var hashedFallbackKey []byte
 	signingKey := defaultClient.h.GetSigningKey()
 	if signingKey == "" {
-		return nil, fmt.Errorf("signing key is required")
-	}
+		if !defaultClient.h.isDev() {
+			// Signing key is only required in cloud mode.
+			return nil, fmt.Errorf("signing key is required")
+		}
+	} else {
+		var err error
+		hashedKey, err = hashedSigningKey([]byte(signingKey))
+		if err != nil {
+			return nil, fmt.Errorf("failed to hash signing key: %w", err)
+		}
 
-	hashedKey, err := hashedSigningKey([]byte(signingKey))
-	if err != nil {
-		return nil, fmt.Errorf("failed to hash signing key: %w", err)
-	}
-
-	var hashedFallbackKey []byte
-	{
 		if fallbackKey := defaultClient.h.GetSigningKeyFallback(); fallbackKey != "" {
 			hashedFallbackKey, err = hashedSigningKey([]byte(fallbackKey))
 			if err != nil {

--- a/connect/handler.go
+++ b/connect/handler.go
@@ -5,6 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
+	"net/url"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"time"
+
 	"github.com/coder/websocket"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/sdk"
@@ -13,13 +21,6 @@ import (
 	"github.com/inngest/inngestgo/internal/sdkrequest"
 	"github.com/pbnjay/memory"
 	"golang.org/x/sync/errgroup"
-	"io"
-	"log/slog"
-	"net/url"
-	"os"
-	"runtime"
-	"sync/atomic"
-	"time"
 )
 
 const (
@@ -159,7 +160,7 @@ type authContext struct {
 
 func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) {
 	signingKey := h.opts.HashedSigningKey
-	if len(signingKey) == 0 {
+	if len(signingKey) == 0 && !h.opts.IsDev {
 		return nil, fmt.Errorf("hashed signing key is required")
 	}
 

--- a/connect/workerapi.go
+++ b/connect/workerapi.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/inngest/inngest/proto/gen/connect/v1"
-	"google.golang.org/protobuf/proto"
 	"io"
 	"log/slog"
 	"net/http"
+
+	"github.com/inngest/inngest/proto/gen/connect/v1"
+	"google.golang.org/protobuf/proto"
 )
 
 type workerApiClient struct {
@@ -36,7 +37,9 @@ func (a *workerApiClient) start(ctx context.Context, hashedSigningKey []byte, re
 	}
 
 	httpReq.Header.Set("Content-Type", "application/protobuf")
-	httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", string(hashedSigningKey)))
+	if hashedSigningKey != nil {
+		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", string(hashedSigningKey)))
+	}
 
 	if a.env != nil {
 		httpReq.Header.Add("X-Inngest-Env", *a.env)
@@ -96,7 +99,9 @@ func (a *workerApiClient) sendBufferedMessage(ctx context.Context, hashedSigning
 	}
 
 	httpReq.Header.Set("Content-Type", "application/protobuf")
-	httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", string(hashedSigningKey)))
+	if hashedSigningKey != nil {
+		httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", string(hashedSigningKey)))
+	}
 
 	if a.env != nil {
 		httpReq.Header.Add("X-Inngest-Env", *a.env)

--- a/handler.go
+++ b/handler.go
@@ -136,14 +136,14 @@ func (h handlerOpts) GetSigningKeyFallback() string {
 
 // GetAPIOrigin returns the host to use for sending API requests
 func (h handlerOpts) GetAPIBaseURL() string {
-	if h.isDev() {
-		return DevServerURL()
-	}
-
 	if h.APIBaseURL == nil {
 		base := os.Getenv("INNGEST_API_BASE_URL")
 		if base != "" {
 			return base
+		}
+
+		if h.isDev() {
+			return DevServerURL()
 		}
 
 		return defaultAPIOrigin

--- a/handler_test.go
+++ b/handler_test.go
@@ -1044,6 +1044,7 @@ func TestConnectSync(t *testing.T) {
 		c, err := NewClient(ClientOpts{
 			APIBaseURL: toPtr(server.URL),
 			AppID:      "app",
+			SigningKey: toPtr(testKey),
 		})
 		r.NoError(err)
 

--- a/tests/invoke_test.go
+++ b/tests/invoke_test.go
@@ -15,9 +15,7 @@ import (
 )
 
 func TestInvoke(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
+	devEnv(t)
 
 	t.Run("success", func(t *testing.T) {
 		ctx := context.Background()

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -29,19 +29,17 @@ func TestMain(m *testing.M) {
 }
 
 func setup() (func() error, error) {
-	os.Setenv("INNGEST_DEV", "1")
-
-	if os.Getenv("DEV_SERVER_ENABLED") == "0" {
-		// Don't start the Dev Server.
-		return func() error { return nil }, nil
-	}
-
 	stopDevServer, err := startDevServer()
 	if err != nil {
 		return nil, err
 	}
 
 	return stopDevServer, nil
+}
+
+func devEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("INNGEST_DEV", "1")
 }
 
 func startDevServer() (func() error, error) {

--- a/tests/parallel_test.go
+++ b/tests/parallel_test.go
@@ -13,10 +13,7 @@ import (
 )
 
 func TestParallel(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-
+	devEnv(t)
 	t.Run("successful with a mix of step kinds", func(t *testing.T) {
 		ctx := context.Background()
 		r := require.New(t)

--- a/tests/probe_test.go
+++ b/tests/probe_test.go
@@ -16,6 +16,8 @@ import (
 const sKey = "signkey-prod-000000"
 
 func TestTrustProbe(t *testing.T) {
+	devEnv(t)
+
 	t.Run("dev mode", func(t *testing.T) {
 		isDev := true
 

--- a/tests/request_context_test.go
+++ b/tests/request_context_test.go
@@ -15,6 +15,7 @@ import (
 func TestRequestContext(t *testing.T) {
 	// Request context values are accessible within Inngest functions.
 
+	devEnv(t)
 	type contextKeyType struct{}
 	contextKey := contextKeyType{}
 

--- a/tests/send_test.go
+++ b/tests/send_test.go
@@ -13,9 +13,7 @@ import (
 )
 
 func TestSend(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
+	devEnv(t)
 
 	t.Run("success", func(t *testing.T) {
 		ctx := context.Background()
@@ -143,9 +141,7 @@ func TestSend(t *testing.T) {
 }
 
 func TestSendMany(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
+	devEnv(t)
 
 	t.Run("success", func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
- Fix Connect requiring signing key in dev mode.
- Fix Connect panicking when no logger passed to client.
- Fix `APIBaseURL` not used when in dev mode.
- Fix env var bleeding during tests.