### PR TITLE
Fix step.Send not accepting GenericEvent

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: '1.24'
       - name: Lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.61.0
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.64.7
           ./bin/golangci-lint run --verbose
   test-linux-race:
     strategy:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.61.0
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Unit test
         run: go test -v -race -count=1 -short
   itest:
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       
       # Need npx to start the Dev Server
       - name: Set up Node.js

--- a/event.go
+++ b/event.go
@@ -1,8 +1,6 @@
 package inngestgo
 
 import (
-	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/inngest/inngestgo/internal"
@@ -19,74 +17,7 @@ const (
 )
 
 type Event = internal.Event
-
-// GenericEvent represents a single event generated from your system to be sent to
-// Inngest.
-type GenericEvent[DATA any, USER any] struct {
-	// ID is an optional event ID used for deduplication.
-	ID *string `json:"id,omitempty"`
-	// Name represents the name of the event.  We recommend the following
-	// simple format: "noun.action".  For example, this may be "signup.new",
-	// "payment.succeeded", "email.sent", "post.viewed".
-	//
-	// Name is required.
-	Name string `json:"name"`
-
-	// Data is a struct or key-value map of data belonging to the event.  This should
-	// include all relevant data.  For example, a "signup.new" event may include
-	// the user's email, their plan information, the signup method, etc.
-	Data DATA `json:"data"`
-
-	// User is a struct or key-value map of data belonging to the user that authored the
-	// event.  This data will be upserted into the contact store.
-	//
-	// We match the user via one of two fields: "external_id" and "email", defined
-	// as consts within this package.
-	//
-	// If these fields are present in this map the attributes specified here
-	// will be updated within Inngest, and the event will be attributed to
-	// this contact.
-	User USER `json:"user,omitempty"`
-
-	// Timestamp is the time the event occured at *millisecond* (not nanosecond)
-	// precision.  This defaults to the time the event is received if left blank.
-	//
-	// Inngest does not guarantee that events are processed within the
-	// order specified by this field.  However, we do guarantee that user data
-	// is stored correctly according to this timestamp.  For example,  if there
-	// two events set the same user attribute, the event with the latest timestamp
-	// is guaranteed to set the user attributes correctly.
-	Timestamp int64 `json:"ts,omitempty"`
-
-	// Version represents the event's version.  Versions can be used to denote
-	// when the structure of an event changes over time.
-	//
-	// Versions typically change when the keys in `Data` change, allowing you to
-	// keep the same event name (eg. "signup.new") as fields change within data
-	// over time.
-	//
-	// We recommend the versioning scheme "YYYY-MM-DD.XX", where .XX increments:
-	// "2021-03-19.01".
-	Version string `json:"v,omitempty"`
-}
-
-// Event() turns the GenericEvent into a normal Event.
-//
-// NOTE: This is a naive inefficient implementation and should not be used in performance
-// constrained systems.
-func (ge GenericEvent[D, U]) Event() Event {
-	byt, _ := json.Marshal(ge)
-	val := Event{}
-	_ = json.Unmarshal(byt, &val)
-	return val
-}
-
-func (ge GenericEvent[D, U]) Validate() error {
-	if ge.Name == "" {
-		return fmt.Errorf("event name must be present")
-	}
-	return nil
-}
+type GenericEvent[DATA any, USER any] = internal.GenericEvent[DATA, USER]
 
 // NowMillis returns a timestamp with millisecond precision used for the Event.Timestamp
 // field.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/inngest/inngestgo
 
-go 1.23.2
+go 1.24
 
 require (
 	github.com/coder/websocket v1.8.12

--- a/internal/event.go
+++ b/internal/event.go
@@ -1,11 +1,16 @@
 package internal
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
 
-type Event struct {
+// GenericEvent represents a single event generated from your system to be sent to
+// Inngest.
+type GenericEvent[DATA any, USER any] struct {
 	// ID is an optional event ID used for deduplication.
 	ID *string `json:"id,omitempty"`
-
 	// Name represents the name of the event.  We recommend the following
 	// simple format: "noun.action".  For example, this may be "signup.new",
 	// "payment.succeeded", "email.sent", "post.viewed".
@@ -13,12 +18,12 @@ type Event struct {
 	// Name is required.
 	Name string `json:"name"`
 
-	// Data is a key-value map of data belonging to the event.  This should
+	// Data is a struct or key-value map of data belonging to the event.  This should
 	// include all relevant data.  For example, a "signup.new" event may include
 	// the user's email, their plan information, the signup method, etc.
-	Data map[string]any `json:"data"`
+	Data DATA `json:"data"`
 
-	// User is a key-value map of data belonging to the user that authored the
+	// User is a struct or key-value map of data belonging to the user that authored the
 	// event.  This data will be upserted into the contact store.
 	//
 	// We match the user via one of two fields: "external_id" and "email", defined
@@ -27,7 +32,7 @@ type Event struct {
 	// If these fields are present in this map the attributes specified here
 	// will be updated within Inngest, and the event will be attributed to
 	// this contact.
-	User any `json:"user,omitempty"`
+	User USER `json:"user,omitempty"`
 
 	// Timestamp is the time the event occured at *millisecond* (not nanosecond)
 	// precision.  This defaults to the time the event is received if left blank.
@@ -51,42 +56,95 @@ type Event struct {
 	Version string `json:"v,omitempty"`
 }
 
-// Validate returns  an error if the event is not well formed
-func (e *Event) Validate() error {
-	if e.Name == "" {
+// Event() turns the GenericEvent into a normal Event.
+//
+// NOTE: This is a naive inefficient implementation and should not be used in performance
+// constrained systems.
+func (ge GenericEvent[D, U]) Event() Event {
+	byt, _ := json.Marshal(ge)
+	val := Event{}
+	_ = json.Unmarshal(byt, &val)
+	return val
+}
+
+func (ge GenericEvent[D, U]) Validate() error {
+	if ge.Name == "" {
 		return fmt.Errorf("event name must be present")
 	}
-	if e.Data == nil {
-		// Ensure that e.Data is not nil.
-		e.Data = make(map[string]any)
+
+	if !isValidEventData(ge.Data) {
+		return fmt.Errorf("data must be a map or struct")
 	}
+
+	if !isValidEventData(ge.User) {
+		return fmt.Errorf("user must be a map or struct")
+	}
+
 	return nil
 }
 
-func (e Event) Map() map[string]any {
-	if e.Data == nil {
-		e.Data = make(map[string]any)
-	}
-	if e.User == nil {
-		e.User = make(map[string]any)
+func (ge GenericEvent[D, U]) Map() map[string]any {
+	var data any = ge.Data
+	if reflect.TypeOf(data).Kind() == reflect.Ptr && reflect.ValueOf(data).IsNil() {
+		data = make(map[string]any)
 	}
 
-	data := map[string]any{
-		"name": e.Name,
-		"data": e.Data,
-		"user": e.User,
+	var user any = ge.User
+	if reflect.TypeOf(user).Kind() == reflect.Ptr && reflect.ValueOf(user).IsNil() {
+		user = make(map[string]any)
+	}
+
+	out := map[string]any{
+		"name": ge.Name,
+		"data": data,
+		"user": ge.User,
 		// We cast to float64 because marshalling and unmarshalling from
 		// JSON automatically uses float64 as its type;  JS has no notion
 		// of ints.
-		"ts": float64(e.Timestamp),
+		"ts": float64(ge.Timestamp),
 	}
 
-	if e.Version != "" {
-		data["v"] = e.Version
+	if ge.Version != "" {
+		out["v"] = ge.Version
 	}
-	if e.ID != nil {
-		data["id"] = *e.ID
+	if ge.ID != nil {
+		out["id"] = *ge.ID
 	}
 
-	return data
+	return out
+}
+
+type Event = GenericEvent[map[string]any, map[string]any]
+
+// isValidEventData checks if the given vaue is one of: nil, map, or struct.
+func isValidEventData(v any) bool {
+	if v == nil {
+		return true
+	}
+
+	isDataMap := reflect.TypeOf(v).Kind() == reflect.Map
+	if isDataMap {
+		return true
+	}
+
+	isDataStruct := reflect.TypeOf(v).Kind() == reflect.Struct
+	if isDataStruct {
+		return true
+	}
+
+	if reflect.TypeOf(v).Kind() == reflect.Ptr {
+		if reflect.ValueOf(v).IsNil() {
+			return false
+		}
+
+		val := reflect.ValueOf(v).Elem()
+		if val.Kind() == reflect.Map {
+			return true
+		}
+		if val.Kind() == reflect.Struct {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/event.go
+++ b/internal/event.go
@@ -89,11 +89,6 @@ func (ge GenericEvent[D, U]) Map() map[string]any {
 		data = make(map[string]any)
 	}
 
-	var user any = ge.User
-	if reflect.TypeOf(user).Kind() == reflect.Ptr && reflect.ValueOf(user).IsNil() {
-		user = make(map[string]any)
-	}
-
 	out := map[string]any{
 		"name": ge.Name,
 		"data": data,

--- a/step/send.go
+++ b/step/send.go
@@ -8,10 +8,10 @@ import (
 )
 
 // Send sends an event to Inngest.
-func Send(
+func Send[D any, U any](
 	ctx context.Context,
 	id string,
-	event internal.Event,
+	event internal.GenericEvent[D, U],
 ) (string, error) {
 	return Run(ctx, id, func(ctx context.Context) (string, error) {
 		sender, ok := internal.EventSenderFromContext(ctx)
@@ -24,10 +24,10 @@ func Send(
 }
 
 // SendMany sends a batch of events to Inngest.
-func SendMany(
+func SendMany[D any, U any](
 	ctx context.Context,
 	id string,
-	events []internal.Event,
+	events []internal.GenericEvent[D, U],
 ) ([]string, error) {
 	return Run(ctx, id, func(ctx context.Context) ([]string, error) {
 		sender, ok := internal.EventSenderFromContext(ctx)

--- a/tests/client_send_test.go
+++ b/tests/client_send_test.go
@@ -1,0 +1,135 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/inngest/inngestgo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientSend(t *testing.T) {
+	devEnv(t)
+
+	r := require.New(t)
+	c, err := inngestgo.NewClient(inngestgo.ClientOpts{
+		AppID: randomSuffix("app"),
+	})
+	r.NoError(err)
+
+	t.Run("empty data", func(t *testing.T) {
+		ctx := context.Background()
+		r := require.New(t)
+
+		// Event type with no data.
+		id, err := c.Send(ctx, inngestgo.Event{Name: "test"})
+		r.NoError(err)
+		r.NotEmpty(id)
+
+		// GenericEvent type with no data.
+		id, err = c.Send(ctx, inngestgo.GenericEvent[map[string]any, any]{
+			Name: "test",
+		})
+		r.NoError(err)
+		r.NotEmpty(id)
+	})
+
+	t.Run("struct pointer", func(t *testing.T) {
+		ctx := context.Background()
+		r := require.New(t)
+
+		type MyEventData = struct{}
+		id, err := c.Send(ctx, inngestgo.GenericEvent[*MyEventData, any]{
+			Name: "test",
+			Data: &MyEventData{},
+		})
+		r.NoError(err)
+		r.NotEmpty(id)
+	})
+
+	t.Run("invalid data", func(t *testing.T) {
+		t.Run("nil pointer", func(t *testing.T) {
+			ctx := context.Background()
+			r := require.New(t)
+
+			type MyEventData = struct{}
+			_, err := c.Send(ctx, inngestgo.GenericEvent[*MyEventData, any]{
+				Name: "test",
+			})
+			r.Error(err)
+			r.Contains(err.Error(), "data must be a map or struct")
+		})
+
+		t.Run("slice", func(t *testing.T) {
+			ctx := context.Background()
+			r := require.New(t)
+
+			_, err = c.Send(ctx, inngestgo.GenericEvent[[]string, any]{
+				Data: []string{"foo", "bar"},
+				Name: "test",
+			})
+			r.Error(err)
+			r.Contains(err.Error(), "data must be a map or struct")
+		})
+
+		t.Run("bool", func(t *testing.T) {
+			ctx := context.Background()
+			r := require.New(t)
+
+			_, err = c.Send(ctx, inngestgo.GenericEvent[bool, any]{
+				Data: true,
+				Name: "test",
+			})
+			r.Error(err)
+			r.Contains(err.Error(), "data must be a map or struct")
+		})
+
+		t.Run("int", func(t *testing.T) {
+			ctx := context.Background()
+			r := require.New(t)
+
+			_, err = c.Send(ctx, inngestgo.GenericEvent[int, any]{
+				Data: 1,
+				Name: "test",
+			})
+			r.Error(err)
+			r.Contains(err.Error(), "data must be a map or struct")
+		})
+
+		t.Run("string", func(t *testing.T) {
+			ctx := context.Background()
+			r := require.New(t)
+
+			_, err = c.Send(ctx, inngestgo.GenericEvent[string, any]{
+				Data: "foo",
+				Name: "test",
+			})
+			r.Error(err)
+			r.Contains(err.Error(), "data must be a map or struct")
+		})
+	})
+}
+
+func TestClientSendMany(t *testing.T) {
+	devEnv(t)
+
+	t.Run("empty data", func(t *testing.T) {
+		ctx := context.Background()
+		r := require.New(t)
+
+		c, err := inngestgo.NewClient(inngestgo.ClientOpts{
+			AppID: randomSuffix("app"),
+		})
+		r.NoError(err)
+
+		ids, err := c.SendMany(ctx, []any{
+			inngestgo.Event{Name: "test"},
+			inngestgo.Event{Name: "test"},
+		})
+		r.NoError(err)
+		r.Len(ids, 2)
+		for _, id := range ids {
+			r.NotEmpty(id)
+		}
+	})
+}

--- a/tests/step_send_test.go
+++ b/tests/step_send_test.go
@@ -12,18 +12,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSend(t *testing.T) {
+func TestStepSend(t *testing.T) {
 	devEnv(t)
 
-	t.Run("success", func(t *testing.T) {
+	t.Run("Event type", func(t *testing.T) {
+		// Successfully send the builtin event type.
+
 		ctx := context.Background()
 		r := require.New(t)
+
+		type MyEvent = inngestgo.Event
 
 		appName := randomSuffix("app")
 		c, err := inngestgo.NewClient(inngestgo.ClientOpts{AppID: appName})
 		r.NoError(err)
 
-		var receivedEventID string
+		var receivedEvent *MyEvent
 		childEventName := randomSuffix("child-event")
 		_, err = inngestgo.CreateFunction(
 			c,
@@ -34,9 +38,9 @@ func TestSend(t *testing.T) {
 			inngestgo.EventTrigger(childEventName, nil),
 			func(
 				ctx context.Context,
-				input inngestgo.Input[inngestgo.GenericEvent[any, any]],
+				input inngestgo.Input[MyEvent],
 			) (any, error) {
-				receivedEventID = *input.Event.ID
+				receivedEvent = &input.Event
 				return nil, nil
 			},
 		)
@@ -53,11 +57,17 @@ func TestSend(t *testing.T) {
 				Retries: inngestgo.IntPtr(0),
 			},
 			inngestgo.EventTrigger(eventName, nil),
-			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+			func(
+				ctx context.Context,
+				input inngestgo.Input[MyEvent],
+			) (any, error) {
 				runID = input.InputCtx.RunID
 				sentEventID, sendErr = step.Send(ctx,
 					"send",
-					inngestgo.Event{Name: childEventName},
+					MyEvent{
+						Data: map[string]any{"msg": "hi"},
+						Name: childEventName,
+					},
 				)
 				return nil, sendErr
 			},
@@ -68,7 +78,7 @@ func TestSend(t *testing.T) {
 		defer server.Close()
 		r.NoError(sync())
 
-		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
+		_, err = c.Send(ctx, MyEvent{Name: eventName})
 		r.NoError(err)
 
 		var run *Run
@@ -81,11 +91,104 @@ func TestSend(t *testing.T) {
 			}
 
 			a.Equal(enums.RunStatusCompleted.String(), run.Status)
-			a.Equal(sentEventID, receivedEventID)
+			if !a.NotNil(receivedEvent) {
+				return
+			}
+			a.Equal(sentEventID, *receivedEvent.ID)
+			a.Equal(map[string]any{"msg": "hi"}, receivedEvent.Data)
 			a.NoError(sendErr)
 		}, 5*time.Second, time.Second)
 	})
-	t.Run("error", func(t *testing.T) {
+
+	t.Run("GenericEvent type", func(t *testing.T) {
+		// Successfully send a custom event type.
+
+		ctx := context.Background()
+		r := require.New(t)
+
+		type MyEventData = struct {
+			Msg string
+		}
+		type MyEvent = inngestgo.GenericEvent[MyEventData, any]
+
+		appName := randomSuffix("app")
+		c, err := inngestgo.NewClient(inngestgo.ClientOpts{AppID: appName})
+		r.NoError(err)
+
+		var receivedEvent *MyEvent
+		childEventName := randomSuffix("child-event")
+		_, err = inngestgo.CreateFunction(
+			c,
+			inngestgo.FunctionOpts{
+				ID:      "child-fn",
+				Retries: inngestgo.IntPtr(0),
+			},
+			inngestgo.EventTrigger(childEventName, nil),
+			func(
+				ctx context.Context,
+				input inngestgo.Input[MyEvent],
+			) (any, error) {
+				receivedEvent = &input.Event
+				return nil, nil
+			},
+		)
+		r.NoError(err)
+
+		var runID string
+		var sentEventID string
+		var sendErr error
+		eventName := randomSuffix("event")
+		_, err = inngestgo.CreateFunction(
+			c,
+			inngestgo.FunctionOpts{
+				ID:      "parent-fn",
+				Retries: inngestgo.IntPtr(0),
+			},
+			inngestgo.EventTrigger(eventName, nil),
+			func(
+				ctx context.Context,
+				input inngestgo.Input[MyEvent],
+			) (any, error) {
+				runID = input.InputCtx.RunID
+				sentEventID, sendErr = step.Send(ctx,
+					"send",
+					MyEvent{
+						Data: MyEventData{Msg: "hi"},
+						Name: childEventName,
+					},
+				)
+				return nil, sendErr
+			},
+		)
+		r.NoError(err)
+
+		server, sync := serve(t, c)
+		defer server.Close()
+		r.NoError(sync())
+
+		_, err = c.Send(ctx, MyEvent{Name: eventName})
+		r.NoError(err)
+
+		var run *Run
+		r.EventuallyWithT(func(ct *assert.CollectT) {
+			a := assert.New(ct)
+
+			run, err = getRun(runID)
+			if !a.NoError(err) {
+				return
+			}
+
+			a.Equal(enums.RunStatusCompleted.String(), run.Status)
+			if !a.NotNil(receivedEvent) {
+				return
+			}
+			a.Equal(sentEventID, *receivedEvent.ID)
+			a.Equal(MyEventData{Msg: "hi"}, receivedEvent.Data)
+			a.NoError(sendErr)
+		}, 5*time.Second, time.Second)
+	})
+
+	t.Run("error due to internal event name", func(t *testing.T) {
 		ctx := context.Background()
 		r := require.New(t)
 
@@ -140,12 +243,16 @@ func TestSend(t *testing.T) {
 	})
 }
 
-func TestSendMany(t *testing.T) {
+func TestStepSendMany(t *testing.T) {
 	devEnv(t)
 
-	t.Run("success", func(t *testing.T) {
+	t.Run("Event type", func(t *testing.T) {
+		// Successfully send the builtin event type.
+
 		ctx := context.Background()
 		r := require.New(t)
+
+		type MyEvent = inngestgo.Event
 
 		appName := randomSuffix("app")
 		c, err := inngestgo.NewClient(inngestgo.ClientOpts{AppID: appName})
@@ -162,11 +269,14 @@ func TestSendMany(t *testing.T) {
 				Retries: inngestgo.IntPtr(0),
 			},
 			inngestgo.EventTrigger(eventName, nil),
-			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+			func(
+				ctx context.Context,
+				input inngestgo.Input[MyEvent],
+			) (any, error) {
 				runID = input.InputCtx.RunID
 				sentEventIDs, sendErr = step.SendMany(ctx,
 					"send",
-					[]inngestgo.Event{
+					[]MyEvent{
 						{Name: randomSuffix("child-event")},
 						{Name: randomSuffix("child-event")},
 					},
@@ -180,7 +290,7 @@ func TestSendMany(t *testing.T) {
 		defer server.Close()
 		r.NoError(sync())
 
-		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
+		_, err = c.Send(ctx, MyEvent{Name: eventName})
 		r.NoError(err)
 
 		var run *Run
@@ -197,7 +307,73 @@ func TestSendMany(t *testing.T) {
 			a.NoError(sendErr)
 		}, 5*time.Second, time.Second)
 	})
-	t.Run("error", func(t *testing.T) {
+
+	t.Run("GenericEvent type", func(t *testing.T) {
+		// Successfully send a custom event type.
+
+		ctx := context.Background()
+		r := require.New(t)
+
+		type MyEventData = struct {
+			Msg string
+		}
+		type MyEvent = inngestgo.GenericEvent[MyEventData, any]
+
+		appName := randomSuffix("app")
+		c, err := inngestgo.NewClient(inngestgo.ClientOpts{AppID: appName})
+		r.NoError(err)
+
+		var runID string
+		var sentEventIDs []string
+		var sendErr error
+		eventName := randomSuffix("event")
+		_, err = inngestgo.CreateFunction(
+			c,
+			inngestgo.FunctionOpts{
+				ID:      "parent-fn",
+				Retries: inngestgo.IntPtr(0),
+			},
+			inngestgo.EventTrigger(eventName, nil),
+			func(
+				ctx context.Context,
+				input inngestgo.Input[MyEvent],
+			) (any, error) {
+				runID = input.InputCtx.RunID
+				sentEventIDs, sendErr = step.SendMany(ctx,
+					"send",
+					[]MyEvent{
+						{Name: randomSuffix("child-event")},
+						{Name: randomSuffix("child-event")},
+					},
+				)
+				return nil, sendErr
+			},
+		)
+		r.NoError(err)
+
+		server, sync := serve(t, c)
+		defer server.Close()
+		r.NoError(sync())
+
+		_, err = c.Send(ctx, MyEvent{Name: eventName})
+		r.NoError(err)
+
+		var run *Run
+		r.EventuallyWithT(func(ct *assert.CollectT) {
+			a := assert.New(ct)
+
+			run, err = getRun(runID)
+			if !a.NoError(err) {
+				return
+			}
+
+			a.Equal(enums.RunStatusCompleted.String(), run.Status)
+			a.Len(sentEventIDs, 2)
+			a.NoError(sendErr)
+		}, 5*time.Second, time.Second)
+	})
+
+	t.Run("error due to internal event name", func(t *testing.T) {
 		ctx := context.Background()
 		r := require.New(t)
 


### PR DESCRIPTION
- Fix `step.Send` and `step.SendMany` not accepting `GenericEvent`.
- Make `Event` derived from `GenericEvent`.