### PR TITLE
Make group.Parallel public

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -17,6 +17,10 @@ const (
 	defaultEventAPIOrigin = "https://inn.gs"
 )
 
+const (
+	executionVersionV2 = "2"
+)
+
 var (
 	SDKVersion = ""
 )

--- a/group/group.go
+++ b/group/group.go
@@ -13,6 +13,7 @@ type Result struct {
 
 type Results []Result
 
+// AnyError returns an error if any of the results have an error.
 func (r Results) AnyError() error {
 	for _, result := range r {
 		if result.Error != nil {

--- a/group/group.go
+++ b/group/group.go
@@ -11,13 +11,26 @@ type Result struct {
 	Value any
 }
 
+type Results []Result
+
+func (r Results) AnyError() error {
+	for _, result := range r {
+		if result.Error != nil {
+			return result.Error
+		}
+	}
+	return nil
+}
+
+// Parallel runs steps in parallel. Its arguments are callbacks that include
+// steps.
 func Parallel(
 	ctx context.Context,
-	fns ...func(ctx context.Context,
-	) (any, error)) []Result {
+	fns ...func(ctx context.Context) (any, error),
+) Results {
 	ctx = context.WithValue(ctx, step.ParallelKey, true)
 
-	results := []Result{}
+	results := Results{}
 	isPlanned := false
 	ch := make(chan struct{}, 1)
 	var unexpectedPanic any

--- a/headers.go
+++ b/headers.go
@@ -11,6 +11,7 @@ const (
 	HeaderKeyEnv                = "X-Inngest-Env"
 	HeaderKeyExpectedServerKind = "X-Inngest-Expected-Server-Kind"
 	HeaderKeyNoRetry            = "X-Inngest-No-Retry"
+	HeaderKeyReqVersion         = "x-inngest-req-version"
 	HeaderKeyRetryAfter         = "Retry-After"
 	HeaderKeySDK                = "X-Inngest-SDK"
 	HeaderKeyServerKind         = "X-Inngest-Server-Kind"
@@ -31,6 +32,7 @@ func SetBasicRequestHeaders(req *http.Request) {
 
 func SetBasicResponseHeaders(w http.ResponseWriter) {
 	w.Header().Set(HeaderKeyContentType, "application/json")
+	w.Header().Set(HeaderKeyReqVersion, executionVersionV2)
 	w.Header().Set(HeaderKeySDK, HeaderValueSDK)
 	w.Header().Set(HeaderKeyUserAgent, HeaderValueSDK)
 }

--- a/step/run.go
+++ b/step/run.go
@@ -32,7 +32,7 @@ func Run[T any](
 ) (T, error) {
 	targetID := getTargetStepID(ctx)
 	mgr := preflight(ctx)
-	op := mgr.NewOp(enums.OpcodeStep, id, nil)
+	op := mgr.NewOp(enums.OpcodeStepRun, id, nil)
 	hashedID := op.MustHash()
 
 	if val, ok := mgr.Step(op); ok {

--- a/step/run_test.go
+++ b/step/run_test.go
@@ -45,7 +45,7 @@ func TestStep(t *testing.T) {
 			// indexes
 			name = "struct"
 			op := sdkrequest.UnhashedOp{
-				Op: enums.OpcodeStep,
+				Op: enums.OpcodeStepRun,
 				ID: name,
 			}
 
@@ -65,7 +65,7 @@ func TestStep(t *testing.T) {
 			// indexes
 			name = "struct ptrs"
 			op := sdkrequest.UnhashedOp{
-				Op: enums.OpcodeStep,
+				Op: enums.OpcodeStepRun,
 				ID: name,
 			}
 
@@ -85,7 +85,7 @@ func TestStep(t *testing.T) {
 				// indexes
 				name = "slices-data"
 				op := sdkrequest.UnhashedOp{
-					Op: enums.OpcodeStep,
+					Op: enums.OpcodeStepRun,
 					ID: name,
 				}
 
@@ -109,7 +109,7 @@ func TestStep(t *testing.T) {
 				// indexes
 				name = "slices-raw"
 				op := sdkrequest.UnhashedOp{
-					Op: enums.OpcodeStep,
+					Op: enums.OpcodeStepRun,
 					ID: name,
 				}
 
@@ -132,7 +132,7 @@ func TestStep(t *testing.T) {
 			// indexes
 			name = "ints"
 			op := sdkrequest.UnhashedOp{
-				Op: enums.OpcodeStep,
+				Op: enums.OpcodeStepRun,
 				ID: name,
 			}
 
@@ -155,7 +155,7 @@ func TestStep(t *testing.T) {
 			// indexes
 			name = "nil"
 			op := sdkrequest.UnhashedOp{
-				Op: enums.OpcodeStep,
+				Op: enums.OpcodeStepRun,
 				ID: name,
 			}
 
@@ -196,7 +196,7 @@ func TestStep(t *testing.T) {
 			}()
 
 			op := sdkrequest.UnhashedOp{
-				Op: enums.OpcodeStep,
+				Op: enums.OpcodeStepRun,
 				ID: name,
 			}
 

--- a/tests/parallel_test.go
+++ b/tests/parallel_test.go
@@ -82,7 +82,15 @@ func TestParallel(t *testing.T) {
 						})
 					},
 				)
-				err := results.AnyError()
+				var err error
+				for _, r := range results {
+					if r.Error != nil {
+						if r.Error == step.ErrEventNotReceived {
+							continue
+						}
+						err = r.Error
+					}
+				}
 				if err != nil {
 					return nil, err
 				}

--- a/tests/parallel_test.go
+++ b/tests/parallel_test.go
@@ -7,24 +7,23 @@ import (
 	"time"
 
 	"github.com/inngest/inngestgo"
-	"github.com/inngest/inngestgo/experimental/group"
+	"github.com/inngest/inngestgo/group"
 	"github.com/inngest/inngestgo/step"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParallel(t *testing.T) {
 	devEnv(t)
+
 	t.Run("successful with a mix of step kinds", func(t *testing.T) {
 		ctx := context.Background()
 		r := require.New(t)
 
-		state := struct {
-			invokedFnCounter int
-			step1ACounter    int
-			step1BCounter    int
-			stepAfterCounter int
-			parallelResults  []group.Result
-		}{}
+		var invokedFnCounter int
+		var step1ACounter int
+		var step1BCounter int
+		var stepAfterCounter int
+		var results group.Results
 
 		appName := randomSuffix("TestParallel")
 		c, err := inngestgo.NewClient(inngestgo.ClientOpts{AppID: appName})
@@ -38,7 +37,7 @@ func TestParallel(t *testing.T) {
 			},
 			inngestgo.EventTrigger("dummy", nil),
 			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
-				state.invokedFnCounter++
+				invokedFnCounter++
 				return "invoked output", nil
 			},
 		)
@@ -53,7 +52,7 @@ func TestParallel(t *testing.T) {
 			},
 			inngestgo.EventTrigger(eventName, nil),
 			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
-				state.parallelResults = group.Parallel(
+				results = group.Parallel(
 					ctx,
 					func(ctx context.Context) (any, error) {
 						return step.Invoke[any](ctx, "invoke", step.InvokeOpts{
@@ -62,13 +61,13 @@ func TestParallel(t *testing.T) {
 					},
 					func(ctx context.Context) (any, error) {
 						return step.Run(ctx, "1a", func(ctx context.Context) (int, error) {
-							state.step1ACounter++
+							step1ACounter++
 							return 1, nil
 						})
 					},
 					func(ctx context.Context) (any, error) {
 						return step.Run(ctx, "1b", func(ctx context.Context) (int, error) {
-							state.step1BCounter++
+							step1BCounter++
 							return 2, nil
 						})
 					},
@@ -83,9 +82,13 @@ func TestParallel(t *testing.T) {
 						})
 					},
 				)
+				err := results.AnyError()
+				if err != nil {
+					return nil, err
+				}
 
-				_, err := step.Run(ctx, "after", func(ctx context.Context) (any, error) {
-					state.stepAfterCounter++
+				_, err = step.Run(ctx, "after", func(ctx context.Context) (any, error) {
+					stepAfterCounter++
 					return nil, nil
 				})
 				if err != nil {
@@ -101,19 +104,16 @@ func TestParallel(t *testing.T) {
 		defer server.Close()
 		r.NoError(sync())
 
-		_, err = c.Send(ctx, inngestgo.Event{
-			Name: eventName,
-			Data: map[string]any{"foo": "bar"}},
-		)
+		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
 		r.NoError(err)
 
 		r.Eventually(func() bool {
-			return state.stepAfterCounter == 1
+			return stepAfterCounter == 1
 		}, 5*time.Second, 10*time.Millisecond)
-		r.Equal(1, state.invokedFnCounter)
-		r.Equal(1, state.step1ACounter)
-		r.Equal(1, state.step1BCounter)
-		r.Equal(state.parallelResults, []group.Result{
+		r.Equal(1, invokedFnCounter)
+		r.Equal(1, step1ACounter)
+		r.Equal(1, step1BCounter)
+		r.Equal(results, group.Results{
 			{Value: "invoked output"},
 			{Value: 1},
 			{Value: 2},
@@ -131,6 +131,7 @@ func TestParallel(t *testing.T) {
 		r.NoError(err)
 
 		var runID string
+		var results group.Results
 		eventName := randomSuffix("my-event")
 		_, err = inngestgo.CreateFunction(
 			c,
@@ -143,7 +144,7 @@ func TestParallel(t *testing.T) {
 			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
 				runID = input.InputCtx.RunID
 
-				group.Parallel(
+				results = group.Parallel(
 					ctx,
 					func(ctx context.Context) (any, error) {
 						return step.Run(ctx, "1a", func(ctx context.Context) (int, error) {
@@ -156,8 +157,7 @@ func TestParallel(t *testing.T) {
 						})
 					},
 				)
-
-				return nil, nil
+				return nil, results.AnyError()
 			},
 		)
 		r.NoError(err)
@@ -166,10 +166,7 @@ func TestParallel(t *testing.T) {
 		defer server.Close()
 		r.NoError(sync())
 
-		_, err = c.Send(ctx, inngestgo.Event{
-			Name: eventName,
-			Data: map[string]any{"foo": "bar"}},
-		)
+		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
 		r.NoError(err)
 
 		run, err := waitForRun(&runID, StatusFailed)
@@ -179,5 +176,90 @@ func TestParallel(t *testing.T) {
 		r.True(ok)
 
 		r.Contains(output["message"], "function panicked: oops")
+	})
+
+	t.Run("sequential steps in group", func(t *testing.T) {
+		ctx := context.Background()
+		r := require.New(t)
+
+		c, err := inngestgo.NewClient(inngestgo.ClientOpts{
+			AppID: randomSuffix("app"),
+		})
+		r.NoError(err)
+
+		// Use a channel to block step 2 until step 1b has finished.
+		ch1B := make(chan struct{})
+
+		var logs []string
+		var step1ACounter int
+		var step1BCounter int
+		var step2Counter int
+		var stepAfterCounter int
+		eventName := randomSuffix("event")
+		_, err = inngestgo.CreateFunction(
+			c,
+			inngestgo.FunctionOpts{
+				ID: "fn",
+			},
+			inngestgo.EventTrigger(eventName, nil),
+			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+				results := group.Parallel(
+					ctx,
+					func(ctx context.Context) (any, error) {
+						_, err := step.Run(ctx, "1a", func(ctx context.Context) (any, error) {
+							logs = append(logs, "1a")
+							step1ACounter++
+							return nil, nil
+						})
+						if err != nil {
+							return nil, err
+						}
+
+						return step.Run(ctx, "1b", func(ctx context.Context) (any, error) {
+							logs = append(logs, "1b")
+							step1BCounter++
+							ch1B <- struct{}{}
+							return nil, nil
+						})
+					},
+					func(ctx context.Context) (any, error) {
+						return step.Run(ctx, "2", func(ctx context.Context) (any, error) {
+							// Wait for 1b to finish
+							<-ch1B
+
+							logs = append(logs, "2")
+							step2Counter++
+							return nil, nil
+						})
+					},
+				)
+				err := results.AnyError()
+				if err != nil {
+					return nil, err
+				}
+
+				return step.Run(ctx, "after", func(ctx context.Context) (any, error) {
+					logs = append(logs, "after")
+					stepAfterCounter++
+					return nil, nil
+				})
+			},
+		)
+		r.NoError(err)
+
+		server, sync := serve(t, c)
+		defer server.Close()
+		r.NoError(sync())
+
+		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
+		r.NoError(err)
+
+		r.Eventually(func() bool {
+			return stepAfterCounter == 1
+		}, 5*time.Second, 10*time.Millisecond)
+		r.Equal(1, step1ACounter)
+		r.Equal(1, step1BCounter)
+		r.Equal(1, step2Counter)
+		r.Equal(logs, []string{"1a", "1b", "2", "after"})
 	})
 }

--- a/tests/parallel_test.go
+++ b/tests/parallel_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngestgo"
 	"github.com/inngest/inngestgo/group"
 	"github.com/inngest/inngestgo/step"
@@ -182,9 +183,7 @@ func TestParallel(t *testing.T) {
 		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
 		r.NoError(err)
 
-		run, err := waitForRun(&runID, StatusFailed)
-		r.NoError(err)
-
+		run := waitForRun(t, &runID, enums.RunStatusFailed.String())
 		output, ok := run.Output.(map[string]any)
 		r.True(ok)
 

--- a/tests/step_wait_for_event_test.go
+++ b/tests/step_wait_for_event_test.go
@@ -1,0 +1,125 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngestgo"
+	"github.com/inngest/inngestgo/step"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStepWaitForEvent(t *testing.T) {
+	devEnv(t)
+
+	t.Run("match", func(t *testing.T) {
+		ctx := context.Background()
+		r := require.New(t)
+
+		c, err := inngestgo.NewClient(inngestgo.ClientOpts{
+			AppID: randomSuffix("my-app"),
+		})
+		r.NoError(err)
+
+		var runID string
+		var stepResult map[string]any
+		var stepError error
+		eventName := randomSuffix("event")
+		_, err = inngestgo.CreateFunction(
+			c,
+			inngestgo.FunctionOpts{
+				ID:      "fn",
+				Retries: inngestgo.IntPtr(0),
+			},
+			inngestgo.EventTrigger(eventName, nil),
+			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+				runID = input.InputCtx.RunID
+				stepResult, stepError = step.WaitForEvent[map[string]any](ctx,
+					"a",
+					step.WaitForEventOpts{
+						Name:    fmt.Sprintf("%s-fulfilled", eventName),
+						Timeout: 10 * time.Second,
+					},
+				)
+				return stepResult, stepError
+			},
+		)
+		r.NoError(err)
+
+		server, sync := serve(t, c)
+		defer server.Close()
+		r.NoError(sync())
+
+		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
+		r.NoError(err)
+
+		// Wait for run to start.
+		r.EventuallyWithT(func(ct *assert.CollectT) {
+			a := assert.New(ct)
+			a.NotEmpty(runID)
+		}, 5*time.Second, time.Second)
+
+		_, err = c.Send(ctx, inngestgo.Event{
+			Name: fmt.Sprintf("%s-fulfilled", eventName),
+			Data: map[string]any{"foo": "bar"},
+		})
+		r.NoError(err)
+
+		waitForRun(t, &runID, enums.RunStatusCompleted.String())
+		r.NoError(stepError)
+		r.Equal(fmt.Sprintf("%s-fulfilled", eventName), stepResult["name"])
+		r.Equal(map[string]any{"foo": "bar"}, stepResult["data"])
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		ctx := context.Background()
+		r := require.New(t)
+
+		c, err := inngestgo.NewClient(inngestgo.ClientOpts{
+			AppID: randomSuffix("my-app"),
+		})
+		r.NoError(err)
+
+		var runID string
+		var stepResult map[string]any
+		var stepError error
+		eventName := randomSuffix("event")
+		_, err = inngestgo.CreateFunction(
+			c,
+			inngestgo.FunctionOpts{
+				ID:      "fn",
+				Retries: inngestgo.IntPtr(0),
+			},
+			inngestgo.EventTrigger(eventName, nil),
+			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+				fmt.Println("run")
+				runID = input.InputCtx.RunID
+				stepResult, stepError = step.WaitForEvent[map[string]any](ctx,
+					"a",
+					step.WaitForEventOpts{
+						Name:    fmt.Sprintf("%s-never", eventName),
+						Timeout: time.Second,
+					},
+				)
+				return stepResult, stepError
+			},
+		)
+		r.NoError(err)
+
+		server, sync := serve(t, c)
+		defer server.Close()
+		r.NoError(sync())
+
+		_, err = c.Send(ctx, inngestgo.Event{Name: eventName})
+		r.NoError(err)
+
+		waitForRun(t, &runID, enums.RunStatusFailed.String())
+		r.Error(stepError)
+		r.ErrorIs(stepError, step.ErrEventNotReceived)
+		r.Nil(stepResult)
+	})
+}

--- a/vendor/github.com/inngest/inngest/pkg/enums/opcode.go
+++ b/vendor/github.com/inngest/inngest/pkg/enums/opcode.go
@@ -6,14 +6,11 @@ type Opcode int
 
 const (
 	// OpcodeNone represents the default opcode 0, which does nothing
-	OpcodeNone Opcode = iota
-
-	// Deprecated: Use OpcodeStepRun instead.
-	OpcodeStep // A step run repsonse, _maybe_ with wrapped data.
-
-	OpcodeStepRun     // Same as OpcodeStep, but guarantees data is not wrapped
-	OpcodeStepError   // A step errored.  The response contains error information.  This can only exist for `step.Run`
-	OpcodeStepPlanned // A step is reported and should be executed next.
+	OpcodeNone        Opcode = iota
+	OpcodeStep               // A step run repsonse, _maybe_ with wrapped data.
+	OpcodeStepRun            // Same as OpcodeStep, but guarantees data is not wrapped
+	OpcodeStepError          // A step errored.  The response contains error information.  This can only exist for `step.Run`
+	OpcodeStepPlanned        // A step is reported and should be executed next.
 	OpcodeSleep
 	OpcodeWaitForEvent
 	OpcodeInvokeFunction

--- a/vendor/github.com/inngest/inngest/pkg/enums/opcode.go
+++ b/vendor/github.com/inngest/inngest/pkg/enums/opcode.go
@@ -6,11 +6,14 @@ type Opcode int
 
 const (
 	// OpcodeNone represents the default opcode 0, which does nothing
-	OpcodeNone        Opcode = iota
-	OpcodeStep               // A step run repsonse, _maybe_ with wrapped data.
-	OpcodeStepRun            // Same as OpcodeStep, but guarantees data is not wrapped
-	OpcodeStepError          // A step errored.  The response contains error information.  This can only exist for `step.Run`
-	OpcodeStepPlanned        // A step is reported and should be executed next.
+	OpcodeNone Opcode = iota
+
+	// Deprecated: Use OpcodeStepRun instead.
+	OpcodeStep // A step run repsonse, _maybe_ with wrapped data.
+
+	OpcodeStepRun     // Same as OpcodeStep, but guarantees data is not wrapped
+	OpcodeStepError   // A step errored.  The response contains error information.  This can only exist for `step.Run`
+	OpcodeStepPlanned // A step is reported and should be executed next.
 	OpcodeSleep
 	OpcodeWaitForEvent
 	OpcodeInvokeFunction


### PR DESCRIPTION
- Move `group.Parallel` out of the `experimental` package.
- Change execution version to v2.