### PR TITLE
Fix client Dev option not always considered

### DIFF
--- a/client.go
+++ b/client.go
@@ -180,11 +180,18 @@ func (a apiClient) GetEventKey() string {
 		return envVar
 	}
 
-	if IsDev() {
+	if a.IsDev() {
 		return "NO_EVENT_KEY_SET"
 	}
 
 	return ""
+}
+
+func (a apiClient) IsDev() bool {
+	if a.Dev != nil {
+		return *a.Dev
+	}
+	return IsDev()
 }
 
 type ServeOpts struct {
@@ -252,7 +259,7 @@ func (a apiClient) SendMany(ctx context.Context, e []any) ([]string, error) {
 	}
 
 	ep := defaultEndpoint
-	if IsDev() {
+	if a.IsDev() {
 		ep = DevServerURL()
 	}
 	if a.EventURL != nil {

--- a/tests/client_send_test.go
+++ b/tests/client_send_test.go
@@ -110,6 +110,24 @@ func TestClientSend(t *testing.T) {
 	})
 }
 
+func TestClientSendDevOption(t *testing.T) {
+	// Client can send events to Dev Server when using the Dev option instead of
+	// the INNGEST_DEV env var
+
+	r := require.New(t)
+	ctx := context.Background()
+
+	c, err := inngestgo.NewClient(inngestgo.ClientOpts{
+		AppID: randomSuffix("app"),
+		Dev:   inngestgo.Ptr(true),
+	})
+	r.NoError(err)
+
+	ids, err := c.Send(ctx, inngestgo.Event{Name: "test"})
+	r.NoError(err)
+	r.NotEmpty(ids)
+}
+
 func TestClientSendMany(t *testing.T) {
 	devEnv(t)
 


### PR DESCRIPTION
Fix a bug where the client didn't think it was in "dev mode" when its `Dev` option was set (as opposed to the `INNGEST_DEV` env var).