### PR TITLE
Fix serve origin and path overrides

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,7 +12,6 @@ import (
 	"math"
 	mathrand "math/rand"
 	"net/http"
-	"net/url"
 	"os"
 	"time"
 
@@ -37,7 +36,6 @@ type Client interface {
 	Serve() http.Handler
 	ServeWithOpts(opts ServeOpts) http.Handler
 	SetOptions(opts ClientOpts) error
-	SetURL(u *url.URL)
 }
 
 type ClientOpts struct {
@@ -90,10 +88,6 @@ type ClientOpts struct {
 
 	// MaxBodySize is the max body size to read for incoming invoke requests
 	MaxBodySize int
-
-	// URL that the function is served at.  If not supplied this is taken from
-	// the incoming request's data.
-	URL *url.URL
 
 	// UseStreaming enables streaming - continued writes to the HTTP writer.  This
 	// differs from true streaming in that we don't support server-sent events.
@@ -160,7 +154,6 @@ func clientOptsToHandlerOpts(opts ClientOpts) handlerOpts {
 		RegisterURL:        opts.RegisterURL,
 		AppVersion:         opts.AppVersion,
 		MaxBodySize:        opts.MaxBodySize,
-		URL:                opts.URL,
 		UseStreaming:       opts.UseStreaming,
 		AllowInBandSync:    opts.AllowInBandSync,
 		Dev:                opts.Dev,
@@ -240,11 +233,6 @@ func (a *apiClient) SetOptions(opts ClientOpts) error {
 	a.ClientOpts = opts
 	a.h.SetOptions(clientOptsToHandlerOpts(opts))
 	return nil
-}
-
-func (a *apiClient) SetURL(u *url.URL) {
-	a.ClientOpts.URL = u
-	a.h.SetOptions(clientOptsToHandlerOpts(a.ClientOpts))
 }
 
 type validatable interface {

--- a/tests/origin_and_path_overrides_test.go
+++ b/tests/origin_and_path_overrides_test.go
@@ -1,0 +1,135 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngestgo"
+	"github.com/inngest/inngestgo/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOriginAndPathOverrides(t *testing.T) {
+	// The serve origin and path can be overridden.
+
+	t.Run("env vars", func(t *testing.T) {
+		r := require.New(t)
+		t.Setenv("INNGEST_SERVE_HOST", "foo.bar.baz")
+		t.Setenv("INNGEST_SERVE_PATH", "/qux/quux")
+
+		var body *types.RegisterRequest
+		mockInngestServer := httptest.NewServer(http.HandlerFunc(func(
+			w http.ResponseWriter,
+			r *http.Request,
+		) {
+			byt, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(byt, &body)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer mockInngestServer.Close()
+
+		appName := randomSuffix("app")
+		ic, err := inngestgo.NewClient(inngestgo.ClientOpts{
+			APIBaseURL: inngestgo.StrPtr(mockInngestServer.URL),
+			AppID:      appName,
+			Dev:        inngestgo.BoolPtr(true),
+		})
+		r.NoError(err)
+		fn, err := inngestgo.CreateFunction(
+			ic,
+			inngestgo.FunctionOpts{ID: "my-fn"},
+			inngestgo.EventTrigger("event", nil),
+			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+				return nil, nil
+			},
+		)
+		r.NoError(err)
+		server := httptest.NewServer(ic.Serve())
+		defer server.Close()
+
+		req, err := http.NewRequest(
+			"PUT",
+			fmt.Sprintf("%s/api/inngest?msg=hi", server.URL),
+			nil,
+		)
+		r.NoError(err)
+		_, err = http.DefaultClient.Do(req)
+		r.NoError(err)
+		r.EventuallyWithT(func(t *assert.CollectT) {
+			a := assert.New(t)
+			a.NotNil(body)
+		}, 5*time.Second, 10*time.Millisecond)
+
+		expectedURL, err := url.Parse("http://foo.bar.baz/qux/quux?msg=hi")
+		r.NoError(err)
+		r.Equal(expectedURL.String(), body.URL)
+
+		r.Len(body.Functions, 1)
+		for _, f := range body.Functions {
+			r.Len(f.Steps, 1)
+			for _, step := range f.Steps {
+				parsedURL, err := url.Parse(step.Runtime["url"].(string))
+				r.NoError(err)
+				r.Equal(expectedURL.Scheme, parsedURL.Scheme)
+				r.Equal(expectedURL.Host, parsedURL.Host)
+				r.Equal(expectedURL.Path, parsedURL.Path)
+
+				qp := parsedURL.Query()
+				r.Equal("hi", qp.Get("msg"))
+				r.Equal("step", qp.Get("step"))
+				r.Equal(fn.FullyQualifiedID(), qp.Get("fnId"))
+			}
+		}
+	})
+
+	t.Run("fields", func(t *testing.T) {
+		r := require.New(t)
+
+		var body *types.RegisterRequest
+		mockInngestServer := httptest.NewServer(http.HandlerFunc(func(
+			w http.ResponseWriter,
+			r *http.Request,
+		) {
+			byt, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(byt, &body)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer mockInngestServer.Close()
+
+		appName := randomSuffix("app")
+		ic, err := inngestgo.NewClient(inngestgo.ClientOpts{
+			APIBaseURL: inngestgo.StrPtr(mockInngestServer.URL),
+			AppID:      appName,
+			Dev:        inngestgo.BoolPtr(true),
+		})
+		r.NoError(err)
+		server := httptest.NewServer(ic.ServeWithOpts(inngestgo.ServeOpts{
+			Origin: inngestgo.StrPtr("foo.bar.baz"),
+			Path:   inngestgo.StrPtr("/qux/quux"),
+		}))
+		defer server.Close()
+
+		req, err := http.NewRequest(
+			"PUT",
+			fmt.Sprintf("%s/api/inngest?msg=hi", server.URL),
+			nil,
+		)
+		r.NoError(err)
+		_, err = http.DefaultClient.Do(req)
+		r.NoError(err)
+		r.EventuallyWithT(func(t *assert.CollectT) {
+			a := assert.New(t)
+			a.NotNil(body)
+		}, 5*time.Second, 10*time.Millisecond)
+
+		r.Equal("http://foo.bar.baz/qux/quux?msg=hi", body.URL)
+	})
+}


### PR DESCRIPTION
- Fix serve origin and path overrides not working. This fix is downstreamed from the `v0.11` branch.
- [BREAKING CHANGE] Remove `URL` client option. This is obviated by the origin and path serve options.