### PR TITLE
Fix SDK failing to reconnect when gateways are rotated

### DIFF
--- a/connect/invoke.go
+++ b/connect/invoke.go
@@ -258,13 +258,15 @@ func (h *connectHandler) connectInvoke(ctx context.Context, preparedConn *connec
 		// function and manage state appropriately.  Any opcode here takes precedence
 		// over function return values as the function has not yet finished.
 		return &connectproto.SDKResponse{
-			RequestId:  body.RequestId,
-			EnvId:      body.EnvId,
-			AppId:      body.AppId,
-			Status:     connectproto.SDKResponseStatus_NOT_COMPLETED,
-			Body:       serializedOps,
-			NoRetry:    noRetry,
-			RetryAfter: retryAfterVal,
+			RequestId:      body.RequestId,
+			EnvId:          body.EnvId,
+			AppId:          body.AppId,
+			Status:         connectproto.SDKResponseStatus_NOT_COMPLETED,
+			Body:           serializedOps,
+			NoRetry:        noRetry,
+			RetryAfter:     retryAfterVal,
+			SystemTraceCtx: body.SystemTraceCtx,
+			UserTraceCtx:   body.UserTraceCtx,
 		}, nil
 	}
 
@@ -277,12 +279,14 @@ func (h *connectHandler) connectInvoke(ctx context.Context, preparedConn *connec
 
 	// Return the function response.
 	return &connectproto.SDKResponse{
-		RequestId:  body.RequestId,
-		EnvId:      body.EnvId,
-		AppId:      body.AppId,
-		Status:     connectproto.SDKResponseStatus_DONE,
-		Body:       serializedResp,
-		NoRetry:    noRetry,
-		RetryAfter: retryAfterVal,
+		RequestId:      body.RequestId,
+		EnvId:          body.EnvId,
+		AppId:          body.AppId,
+		Status:         connectproto.SDKResponseStatus_DONE,
+		Body:           serializedResp,
+		NoRetry:        noRetry,
+		RetryAfter:     retryAfterVal,
+		SystemTraceCtx: body.SystemTraceCtx,
+		UserTraceCtx:   body.UserTraceCtx,
 	}, nil
 }


### PR DESCRIPTION
I believe we are hitting two separate issues when the SDK is trying to reconnect after rotating gateways:
- SDK is not able to reconnect.
- Flushing API call is failing with a 400.

#### Reconnection issue

The bubbled errors are context cancelled and I believe that I've identified when it actually gets cancelled. cancelStart is called as soon as the handler.Connect call finishes. Which makes the connection fine until it needs to connect again using that same context. That startCtx is only expected to be cancelled/timed out on the first connect call.

https://github.com/inngest/inngestgo/blob/f122af6b1d151757d75365b7ac6b110d992b1ae6/connect/handler.go#L49-L50

#### Flushing API failure

The bad request 400 clause we are hitting is the following and it's likely because [we are not carrying the](https://github.com/inngest/inngestgo/pull/101) `systemTraceCtx` field all the way back to the API call in an `SDKResponse`.
https://github.com/inngest/monorepo/blob/21264bce7af6159b6ce41c47d9dd46bc2e4a82ee/vendor/github.com/inngest/inngest/pkg/connect/rest/v0/workerapi.go#L183-L187