### PR TITLE
Check X-Forwarded-Proto for URL building

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -589,10 +589,7 @@ func (h *handler) outOfBandSync(w http.ResponseWriter, r *http.Request) error {
 	h.l.Lock()
 	defer h.l.Unlock()
 
-	scheme := "http"
-	if r.TLS != nil {
-		scheme = "https"
-	}
+	scheme := getScheme(r)
 	host := r.Host
 
 	// Get the sync ID from the URL and then remove it, since we don't want the
@@ -697,10 +694,7 @@ func (h *handler) url(r *http.Request) *url.URL {
 	}
 
 	// Get the current URL.
-	scheme := "http"
-	if r.TLS != nil {
-		scheme = "https"
-	}
+	scheme := getScheme(r)
 	u, _ := url.Parse(fmt.Sprintf("%s://%s%s", scheme, r.Host, r.RequestURI))
 	return u
 }
@@ -1431,4 +1425,18 @@ func updateInput(
 			fnInput.FieldByName("Events").Set(reflect.ValueOf(newEvents))
 		}
 	}
+}
+
+func getScheme(r *http.Request) string {
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+	    if proto == "https" || proto == "http" {
+	        return proto
+	    }
+	}
+
+	if r.TLS != nil {
+	    return "https"
+	}
+
+	return "http"
 }


### PR DESCRIPTION
When using  behind a load balancer which terminates SSL, r.TLS will be nil. This results in the app being added to Inngest using HTTP.