### PR TITLE
SYS-285: Add support for conditional batching

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -80,6 +80,16 @@ func TestRegister(t *testing.T) {
 		},
 	)
 	r.NoError(err)
+
+	_, err = CreateFunction(
+		c,
+		FunctionOpts{ID: "conditional-batch-func", BatchEvents: &ifn.EventBatchConfig{MaxSize: 20, Timeout: 10 * time.Second, If: toPtr("has(event.data.somefield)")}},
+		EventTrigger("test/batch.a", nil),
+		func(ctx context.Context, input Input[map[string]any]) (any, error) {
+			return nil, nil
+		},
+	)
+	r.NoError(err)
 }
 
 // TestInvoke asserts that invoking a function with both the correct and incorrect type

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -182,9 +182,13 @@ type EventBatchConfig struct {
 	// included in a batch
 	MaxSize int `json:"maxSize"`
 
-	// Timeout is the maximum number of time the batch will
+	// Timeout is the maximum amount of time the batch will
 	// wait before being consumed.
 	Timeout time.Duration `json:"timeout"`
+
+	// If is an optional boolean expression which must evaluate to true for the event to be eligible for batching.
+	// For events where this expression evaluates to false, the event will be scheduled for execution immediately in a non-batched mode
+	If *string `json:"if,omitempty"`
 }
 
 func (t EventBatchConfig) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Add `if` support in the batch config. This conditional boolean expression, when provided, would determine which events get batched together for execution.

If the expression fails to evaluate or if it evaluates to false, the event will be treated ineligible for batching and will be scheduled for execution immediately.