### PR TITLE
Handle sync redirecting

### DIFF
--- a/stephttp/api_client.go
+++ b/stephttp/api_client.go
@@ -29,6 +29,11 @@ type CheckpointRun struct {
 	AppID uuid.UUID `json:"app_id"`
 	// RunID is the function run ID created for this execution.
 	RunID ulid.ULID `json:"run_id"`
+	// Token is the token to use when redirecting if this is an async checkpoint.
+	Token string `json:"token,omitempty"`
+
+	// NOTE: The below are not included in the API response when checkpointing
+	// new runs.
 
 	// Stack is the current stack, used when resuming requests.
 	Stack []string

--- a/stephttp/configure.go
+++ b/stephttp/configure.go
@@ -88,7 +88,7 @@ type AsyncResponseRedirect struct {
 	//
 	// Note that this accepts a token which can be used to hit the Inngest API to
 	// block for the API result.
-	URL func(token string) string
+	URL func(runID ulid.ULID, token string) string
 }
 
 func (a AsyncResponseRedirect) isAsyncResponse() {}

--- a/stephttp/util.go
+++ b/stephttp/util.go
@@ -3,6 +3,7 @@ package stephttp
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -11,13 +12,13 @@ import (
 	"github.com/oklog/ulid/v2"
 )
 
-func redirectToken(runID ulid.ULID) string {
-	// TODO: SIGN WITH A KEY OR RANDOM TOKEN
-	return runID.String()
-}
-
-func defaultRedirectURL(o SetupOpts, runID ulid.ULID) string {
-	return o.baseURL() + "/v2/public/runs/" + redirectToken(runID)
+func defaultRedirectURL(o SetupOpts, runID ulid.ULID, token string) string {
+	return fmt.Sprintf(
+		"%s/v1/http/runs/%s/output?token=%s",
+		o.baseURL(),
+		runID,
+		token,
+	)
 }
 
 // responseWriter captures the response for storing as the API result
@@ -56,10 +57,10 @@ func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if !ok {
 		return nil, nil, http.ErrNotSupported
 	}
-	
+
 	// Mark as hijacked so we stop capturing response data
 	rw.hijacked = true
-	
+
 	return hijacker.Hijack()
 }
 


### PR DESCRIPTION
This commit introduces full redirect support for sync -> async conversion in API-based runs