### PR TITLE
Add support for fn concurrency (alongside step concurrency)

### DIFF
--- a/expose_internal.go
+++ b/expose_internal.go
@@ -56,7 +56,9 @@ type (
 	// 		event.data.account_id
 	//
 	// Concurrency is then limited for each unique account_id field in parent events.
-	ConfigStepConcurrency = fn.Concurrency
+	ConfigStepConcurrency = fn.StepConcurrency
+	ConfigFnConcurrency   = fn.FnConcurrency
+	ConfigConcurrency     = fn.ConcurrencyLimits
 
 	// ConfigCancel represents a cancellation signal for a function.  When specified, this
 	// will set up pauses which automatically cancel the function based off of matching

--- a/funcs.go
+++ b/funcs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/gosimple/slug"
 	"github.com/inngest/inngestgo/internal/event"
@@ -108,6 +109,19 @@ func CronTrigger(cron string) fn.Trigger {
 	return fn.Trigger{
 		CronTrigger: &fn.CronTrigger{
 			Cron: cron,
+		},
+	}
+}
+
+// CronTriggerWithJitter returns a cron trigger with an optional jitter duration.
+// Jitter delays the function execution by a random amount up to the specified duration.
+// The duration is serialized as a string (e.g. "30s") for the server.
+func CronTriggerWithJitter(cron string, jitter time.Duration) fn.Trigger {
+	s := jitter.String()
+	return fn.Trigger{
+		CronTrigger: &fn.CronTrigger{
+			Cron:   cron,
+			Jitter: &s,
 		},
 	}
 }

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -57,7 +57,7 @@ type FunctionOpts struct {
 	// Priority allows you to specify priority options for the function.
 	Priority *Priority
 	// Concurrency allows you to specify concurrency options.
-	Concurrency []Concurrency
+	Concurrency *ConcurrencyLimits
 	// Idempotency allows you to specify a custom idempotency key - evaluated as a CEL expression
 	// using the run's triggering event.
 	Idempotency *string
@@ -137,28 +137,42 @@ type Priority struct {
 	Run *string `json:"run"`
 }
 
-// Concurrency represents a single concurrency limit for a function.  Concurrency limits
-// the number of running steps for a given key at a time.  Other steps will be enqueued
-// for the future and executed as soon as there's capacity.
+// ConcurrencyLimits represents all concurrency limits for a function.
+type ConcurrencyLimits struct {
+	// Fn specifies function-level concurrency limits.  The semaphore is held
+	// for the entire run (manual release on finalization).
+	Fn []FnConcurrency `json:"fn,omitempty"`
+
+	// Step specifies step-level concurrency limits.  Each step independently
+	// acquires and releases capacity.
+	Step []StepConcurrency `json:"step,omitempty"`
+}
+
+// FnConcurrency represents a function-level concurrency limit.  The limit is
+// held for the entire run lifetime and released on finalization.
+type FnConcurrency struct {
+	Limit int     `json:"limit"`
+	Key   *string `json:"key,omitempty"`
+	Hash  string  `json:"hash"`
+}
+
+// StepConcurrency represents a single step-level concurrency limit.
+// Concurrency limits the number of running steps for a given key at a time.
 //
 // # Concurrency keys: virtual queues.
 //
 // The `Key` parameter is an optional CEL expression evaluated using the run's events.
 // The output from the expression is used to create new virtual queues, which limits
 // the number of runs for each virtual queue.
-//
-// For example, to limit the number of running steps for every account in your system,
-// you can send the `account_id` in the triggering event and use the following key:
-//
-//	event.data.account_id
-//
-// Concurrency is then limited for each unique account_id field in parent events.
-type Concurrency struct {
+type StepConcurrency struct {
 	Limit int                    `json:"limit"`
 	Key   *string                `json:"key,omitempty"`
 	Scope enums.ConcurrencyScope `json:"scope"`
 	Hash  string                 `json:"hash"`
 }
+
+// Concurrency is an alias for StepConcurrency for backward compatibility.
+type Concurrency = StepConcurrency
 
 // Cancel represents a cancellation signal for a function.  When specified, this
 // will set up pauses which automatically cancel the function based off of matching

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -130,7 +130,8 @@ type EventTrigger struct {
 
 // CronTrigger is a trigger which invokes the function on a CRON schedule.
 type CronTrigger struct {
-	Cron string `json:"cron"`
+	Cron   string  `json:"cron"`
+	Jitter *string `json:"jitter,omitempty"`
 }
 
 type Priority struct {

--- a/internal/fn/sync.go
+++ b/internal/fn/sync.go
@@ -41,9 +41,7 @@ type SyncConfig struct {
 
 	// Concurrency allows limiting the concurrency of running functions, optionally constrained
 	// by an individual concurrency key.
-	//
-	// This may be an int OR a struct, for backwards compatibility.
-	Concurrency []Concurrency `json:"concurrency,omitempty"`
+	Concurrency *ConcurrencyLimits `json:"concurrency,omitempty"`
 
 	// Priority represents the priority information for this function.
 	Priority *Priority `json:"priority,omitempty"`


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR refactors concurrency configuration to support both function-level (`FnConcurrency`) and step-level (`StepConcurrency`) limits under a new `ConcurrencyLimits` wrapper struct, with a backward-compat type alias `Concurrency = StepConcurrency`. The cherry-picked commit adds `CronTriggerWithJitter` support.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 646b25243923377c285b9c357576cf2cd4e98ac6.</sup>
<!-- /MENDRAL_SUMMARY -->