### PR TITLE
Add jitter field to CronTrigger for cron jitter support

### DIFF
--- a/.changeset/add-cron-jitter.md
+++ b/.changeset/add-cron-jitter.md
@@ -1,0 +1,5 @@
+---
+"inngestgo": patch
+---
+
+Add optional jitter field to CronTrigger and CronTriggerWithJitter helper

--- a/funcs.go
+++ b/funcs.go
@@ -112,6 +112,17 @@ func CronTrigger(cron string) fn.Trigger {
 	}
 }
 
+// CronTriggerWithJitter returns a cron trigger with an optional jitter duration.
+// Jitter delays the function execution by a random amount up to the specified duration.
+func CronTriggerWithJitter(cron string, jitter string) fn.Trigger {
+	return fn.Trigger{
+		CronTrigger: &fn.CronTrigger{
+			Cron:   cron,
+			Jitter: &jitter,
+		},
+	}
+}
+
 // SDKFunction represents a user-defined function to be called based off of events or
 // on a schedule.
 //

--- a/funcs.go
+++ b/funcs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/gosimple/slug"
 	"github.com/inngest/inngestgo/internal/event"
@@ -114,7 +115,7 @@ func CronTrigger(cron string) fn.Trigger {
 
 // CronTriggerWithJitter returns a cron trigger with an optional jitter duration.
 // Jitter delays the function execution by a random amount up to the specified duration.
-func CronTriggerWithJitter(cron string, jitter string) fn.Trigger {
+func CronTriggerWithJitter(cron string, jitter time.Duration) fn.Trigger {
 	return fn.Trigger{
 		CronTrigger: &fn.CronTrigger{
 			Cron:   cron,

--- a/funcs.go
+++ b/funcs.go
@@ -115,11 +115,13 @@ func CronTrigger(cron string) fn.Trigger {
 
 // CronTriggerWithJitter returns a cron trigger with an optional jitter duration.
 // Jitter delays the function execution by a random amount up to the specified duration.
+// The duration is serialized as a string (e.g. "30s") for the server.
 func CronTriggerWithJitter(cron string, jitter time.Duration) fn.Trigger {
+	s := jitter.String()
 	return fn.Trigger{
 		CronTrigger: &fn.CronTrigger{
 			Cron:   cron,
-			Jitter: &jitter,
+			Jitter: &s,
 		},
 	}
 }

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -130,12 +130,8 @@ type EventTrigger struct {
 
 // CronTrigger is a trigger which invokes the function on a CRON schedule.
 type CronTrigger struct {
-	Cron   string         `json:"cron"`
-	Jitter *time.Duration `json:"jitter,omitempty"`
-}
-
-func (c CronTrigger) MarshalJSON() ([]byte, error) {
-	return encodeJSONWithDuration(c, "jitter")
+	Cron   string  `json:"cron"`
+	Jitter *string `json:"jitter,omitempty"`
 }
 
 type Priority struct {

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -130,8 +130,12 @@ type EventTrigger struct {
 
 // CronTrigger is a trigger which invokes the function on a CRON schedule.
 type CronTrigger struct {
-	Cron   string  `json:"cron"`
-	Jitter *string `json:"jitter,omitempty"`
+	Cron   string         `json:"cron"`
+	Jitter *time.Duration `json:"jitter,omitempty"`
+}
+
+func (c CronTrigger) MarshalJSON() ([]byte, error) {
+	return encodeJSONWithDuration(c, "jitter")
 }
 
 type Priority struct {

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -130,7 +130,8 @@ type EventTrigger struct {
 
 // CronTrigger is a trigger which invokes the function on a CRON schedule.
 type CronTrigger struct {
-	Cron string `json:"cron"`
+	Cron   string  `json:"cron"`
+	Jitter *string `json:"jitter,omitempty"`
 }
 
 type Priority struct {


### PR DESCRIPTION
Add optional Jitter field to CronTrigger and a CronTriggerWithJitter helper. This allows SDKs to register cron functions with a jitter duration that delays execution by a random amount after the cron boundary.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds an optional `Jitter` field to `CronTrigger` and a `CronTriggerWithJitter(cron string, jitter time.Duration)` helper. The jitter duration is pre-serialized to a string via `time.Duration.String()` before storage, and `omitempty` on the `*string` field handles nil safely without a custom `MarshalJSON`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 75eadc7f2d982a20c84b2b784ea15b6386066f87.</sup>
<!-- /MENDRAL_SUMMARY -->