### PR TITLE
cherry pick pr 209

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/gosimple/slug"
 	"github.com/inngest/inngestgo/internal/event"
@@ -108,6 +109,19 @@ func CronTrigger(cron string) fn.Trigger {
 	return fn.Trigger{
 		CronTrigger: &fn.CronTrigger{
 			Cron: cron,
+		},
+	}
+}
+
+// CronTriggerWithJitter returns a cron trigger with an optional jitter duration.
+// Jitter delays the function execution by a random amount up to the specified duration.
+// The duration is serialized as a string (e.g. "30s") for the server.
+func CronTriggerWithJitter(cron string, jitter time.Duration) fn.Trigger {
+	s := jitter.String()
+	return fn.Trigger{
+		CronTrigger: &fn.CronTrigger{
+			Cron:   cron,
+			Jitter: &s,
 		},
 	}
 }

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -130,7 +130,8 @@ type EventTrigger struct {
 
 // CronTrigger is a trigger which invokes the function on a CRON schedule.
 type CronTrigger struct {
-	Cron string `json:"cron"`
+	Cron   string  `json:"cron"`
+	Jitter *string `json:"jitter,omitempty"`
 }
 
 type Priority struct {


### PR DESCRIPTION
add jitter to sdk

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `CronTriggerWithJitter` to allow cron triggers with a random jitter delay, serialized as a string. Adds a `Jitter *string` field to the `CronTrigger` struct.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8bbfe3c34af0e2110effc73c5d32b61fcd0e4c20.</sup>
<!-- /MENDRAL_SUMMARY -->