### PR TITLE
feat: use GenerationID to gate stale checkpointing

### DIFF
--- a/expose_internal.go
+++ b/expose_internal.go
@@ -56,7 +56,9 @@ type (
 	// 		event.data.account_id
 	//
 	// Concurrency is then limited for each unique account_id field in parent events.
-	ConfigStepConcurrency = fn.Concurrency
+	ConfigStepConcurrency = fn.StepConcurrency
+	ConfigFnConcurrency   = fn.FnConcurrency
+	ConfigConcurrency     = fn.ConcurrencyLimits
 
 	// ConfigCancel represents a cancellation signal for a function.  When specified, this
 	// will set up pauses which automatically cancel the function based off of matching

--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -2,6 +2,7 @@ package checkpoint
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -13,6 +14,8 @@ import (
 
 type Config = check.Config
 
+var ErrStaleDispatch = errors.New("stale dispatch")
+
 type Opts struct {
 	// RunID is the run ID being checkpointed.
 	RunID string
@@ -21,6 +24,8 @@ type Opts struct {
 	// QueueItemRef represents the queue item ref that's currently leased while
 	// executing the SDK.
 	QueueItemRef string
+	// GenerationID fences checkpoint writes to the active dispatch attempt. It is a monotonic counter the backend bumps on requeue. Zero means the SDK did not receive a value and the fence fails open.
+	GenerationID int
 	// SigningKey is the signing key used to checkpoint.
 	SigningKey string
 	// SigningKeyFallback is the fallback signing key.
@@ -149,6 +154,7 @@ func (c *checkpointer) checkpoint(ctx context.Context, cb Callback) {
 		RunID:        c.opts.RunID,
 		FnID:         c.opts.FnID,
 		QueueItemRef: c.opts.QueueItemRef,
+		GenerationID: c.opts.GenerationID,
 		Steps:        c.buffer,
 	})
 	if err != nil {
@@ -177,6 +183,8 @@ type AsyncRequest struct {
 	// QueueItemRef represents the queue item ID that's currently leased while
 	// executing the SDK.
 	QueueItemRef string `json:"qi_id"`
+	// GenerationID fences checkpoint writes to the active dispatch attempt.
+	GenerationID int `json:"generation_id,omitempty"`
 	// Steps represents the steps being checkpointed.
 	Steps []opcode.Step `json:"steps"`
 }

--- a/internal/checkpoint/checkpoint_test.go
+++ b/internal/checkpoint/checkpoint_test.go
@@ -2,6 +2,7 @@ package checkpoint
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -103,6 +104,38 @@ func TestWithStep_BatchSteps_StillCheckpoints(t *testing.T) {
 
 	// Close should be safe after a completed checkpoint.
 	c.Close()
+}
+
+func TestWithStep_IncludesGenerationID(t *testing.T) {
+	var received AsyncRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&received)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := New(Opts{
+		RunID:        "run-123",
+		QueueItemRef: "qi-456",
+		GenerationID: 789,
+		Config: Config{
+			BatchSteps: 1,
+		},
+		APIBaseURL: server.URL,
+	}).(*checkpointer)
+	c.client.httpClient = server.Client()
+
+	c.WithStep(context.Background(), opcode.Step{
+		Op: enums.OpcodeStepRun,
+		ID: "step-1",
+	}, func(_ []opcode.Step, err error) {
+		require.NoError(t, err)
+	})
+
+	assert.Equal(t, "run-123", received.RunID)
+	assert.Equal(t, "qi-456", received.QueueItemRef)
+	assert.Equal(t, 789, received.GenerationID)
 }
 
 func TestWithStep_BatchInterval_Checkpoints(t *testing.T) {

--- a/internal/checkpoint/client.go
+++ b/internal/checkpoint/client.go
@@ -69,6 +69,10 @@ func (c *Client) do(ctx context.Context, req AsyncRequest) error {
 	}
 
 	if resp.StatusCode >= 400 {
+		if resp.StatusCode == http.StatusConflict {
+			return fmt.Errorf("%w: checkpoint returned 409 conflict: %s", ErrStaleDispatch, byt)
+		}
+
 		// If we get a 401 and have a fallback key, try switching to it
 		if resp.StatusCode == 401 && c.fallbackKey != "" && !c.useFallback.Load() {
 			c.useFallback.Store(true)

--- a/internal/checkpoint/client_test.go
+++ b/internal/checkpoint/client_test.go
@@ -3,6 +3,7 @@ package checkpoint
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -196,6 +197,29 @@ func TestClient_Checkpoint_Non401Error(t *testing.T) {
 	assert.False(t, client.useFallback.Load(), "should not have switched to fallback")
 }
 
+func TestClient_Checkpoint_ConflictReturnsStaleDispatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"stale dispatch"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "primary-key", "fallback-key")
+	client.httpClient = server.Client()
+
+	err := client.Checkpoint(context.Background(), AsyncRequest{
+		RunID:        "run-123",
+		FnID:         uuid.New(),
+		QueueItemRef: "qi-456",
+		GenerationID: 789,
+		Steps:        []opcode.Step{},
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrStaleDispatch))
+	assert.False(t, client.useFallback.Load(), "409 should not switch to fallback auth")
+}
+
 func TestClient_Checkpoint_FallbackAlreadyActive(t *testing.T) {
 	var callCount atomic.Int32
 	var receivedAuthHeaders []string
@@ -258,6 +282,7 @@ func TestClient_Checkpoint_ValidRequestBody(t *testing.T) {
 		RunID:        "run-123",
 		FnID:         fnID,
 		QueueItemRef: "qi-456",
+		GenerationID: 789,
 		Steps: []opcode.Step{
 			{
 				Op: enums.OpcodeStepRun,
@@ -276,6 +301,7 @@ func TestClient_Checkpoint_ValidRequestBody(t *testing.T) {
 	assert.Equal(t, "run-123", receivedBody.RunID)
 	assert.Equal(t, fnID, receivedBody.FnID)
 	assert.Equal(t, "qi-456", receivedBody.QueueItemRef)
+	assert.Equal(t, 789, receivedBody.GenerationID)
 	assert.Len(t, receivedBody.Steps, 2)
 	assert.Equal(t, "step-1", receivedBody.Steps[0].ID)
 	assert.Equal(t, "step-2", receivedBody.Steps[1].ID)

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -57,7 +57,7 @@ type FunctionOpts struct {
 	// Priority allows you to specify priority options for the function.
 	Priority *Priority
 	// Concurrency allows you to specify concurrency options.
-	Concurrency []Concurrency
+	Concurrency *ConcurrencyLimits
 	// Idempotency allows you to specify a custom idempotency key - evaluated as a CEL expression
 	// using the run's triggering event.
 	Idempotency *string
@@ -138,28 +138,42 @@ type Priority struct {
 	Run *string `json:"run"`
 }
 
-// Concurrency represents a single concurrency limit for a function.  Concurrency limits
-// the number of running steps for a given key at a time.  Other steps will be enqueued
-// for the future and executed as soon as there's capacity.
+// ConcurrencyLimits represents all concurrency limits for a function.
+type ConcurrencyLimits struct {
+	// Fn specifies function-level concurrency limits.  The semaphore is held
+	// for the entire run (manual release on finalization).
+	Fn []FnConcurrency `json:"fn,omitempty"`
+
+	// Step specifies step-level concurrency limits.  Each step independently
+	// acquires and releases capacity.
+	Step []StepConcurrency `json:"step,omitempty"`
+}
+
+// FnConcurrency represents a function-level concurrency limit.  The limit is
+// held for the entire run lifetime and released on finalization.
+type FnConcurrency struct {
+	Limit int     `json:"limit"`
+	Key   *string `json:"key,omitempty"`
+	Hash  string  `json:"hash"`
+}
+
+// StepConcurrency represents a single step-level concurrency limit.
+// Concurrency limits the number of running steps for a given key at a time.
 //
 // # Concurrency keys: virtual queues.
 //
 // The `Key` parameter is an optional CEL expression evaluated using the run's events.
 // The output from the expression is used to create new virtual queues, which limits
 // the number of runs for each virtual queue.
-//
-// For example, to limit the number of running steps for every account in your system,
-// you can send the `account_id` in the triggering event and use the following key:
-//
-//	event.data.account_id
-//
-// Concurrency is then limited for each unique account_id field in parent events.
-type Concurrency struct {
+type StepConcurrency struct {
 	Limit int                    `json:"limit"`
 	Key   *string                `json:"key,omitempty"`
 	Scope enums.ConcurrencyScope `json:"scope"`
 	Hash  string                 `json:"hash"`
 }
+
+// Concurrency is an alias for StepConcurrency for backward compatibility.
+type Concurrency = StepConcurrency
 
 // Cancel represents a cancellation signal for a function.  When specified, this
 // will set up pauses which automatically cancel the function based off of matching

--- a/internal/fn/sync.go
+++ b/internal/fn/sync.go
@@ -41,9 +41,7 @@ type SyncConfig struct {
 
 	// Concurrency allows limiting the concurrency of running functions, optionally constrained
 	// by an individual concurrency key.
-	//
-	// This may be an int OR a struct, for backwards compatibility.
-	Concurrency []Concurrency `json:"concurrency,omitempty"`
+	Concurrency *ConcurrencyLimits `json:"concurrency,omitempty"`
 
 	// Priority represents the priority information for this function.
 	Priority *Priority `json:"priority,omitempty"`

--- a/internal/sdkrequest/manager.go
+++ b/internal/sdkrequest/manager.go
@@ -5,10 +5,12 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/inngest/inngest/pkg/enums"
@@ -158,6 +160,7 @@ func NewManager(opts Opts) InvocationManager {
 			RunID:              opts.Request.CallCtx.RunID,
 			FnID:               opts.Request.CallCtx.FunctionID,
 			QueueItemRef:       opts.Request.CallCtx.QueueItemRef,
+			GenerationID:       opts.Request.CallCtx.GenerationID,
 			SigningKey:         opts.SigningKey,
 			SigningKeyFallback: opts.SigningKeyFallback,
 			Config:             checkpointConfig,
@@ -292,6 +295,9 @@ func (r *requestCtxManager) AppendOp(ctx context.Context, op GeneratorOpcode) {
 			panic(ControlHijack{})
 		}
 
+		// stale is atomic because the callback may fire on the checkpointer's
+		// BatchInterval timer goroutine, not just synchronously inside WithStep.
+		var stale atomic.Bool
 		r.checkpointer.WithStep(ctx, op, func(done []opcode.Step, err error) {
 			if err == nil {
 				// Remove each step that's checkpointed from our buffer.  The manager's buffer
@@ -304,8 +310,20 @@ func (r *requestCtxManager) AppendOp(ctx context.Context, op GeneratorOpcode) {
 				}
 				return
 			}
+			if errors.Is(err, checkpoint.ErrStaleDispatch) {
+				// A stale dispatch must contribute nothing to the SDK response,
+				// otherwise the executor saves our buffered ops as idempotent and
+				// chains the next step off this dead invocation (EXE-1552).
+				r.ops = nil
+				r.cancel()
+				stale.Store(true)
+				return
+			}
 			slog.Default().Warn("error checkpointing state, falling back to async response", "error", err)
 		})
+		if stale.Load() {
+			panic(ControlHijack{})
+		}
 	default:
 		// Do nothing else.
 	}

--- a/internal/sdkrequest/manager_test.go
+++ b/internal/sdkrequest/manager_test.go
@@ -1,0 +1,107 @@
+package sdkrequest
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngestgo/internal/checkpoint"
+	"github.com/inngest/inngestgo/internal/fn"
+	"github.com/inngest/inngestgo/internal/opcode"
+	checkpointpkg "github.com/inngest/inngestgo/pkg/checkpoint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testFunction struct {
+	config fn.FunctionOpts
+}
+
+func (f testFunction) FullyQualifiedID() string { return "test-fn" }
+func (f testFunction) ID() string               { return "test-fn" }
+func (f testFunction) Name() string             { return "test fn" }
+func (f testFunction) Config() fn.FunctionOpts  { return f.config }
+func (f testFunction) Trigger() fn.Triggerable  { return nil }
+func (f testFunction) ZeroEvent() any           { return nil }
+func (f testFunction) Func() any                { return nil }
+
+func TestCallCtxGenerationIDUnmarshal(t *testing.T) {
+	var req Request
+	err := json.Unmarshal([]byte(`{"ctx":{"generation_id":789}}`), &req)
+
+	require.NoError(t, err)
+	assert.Equal(t, 789, req.CallCtx.GenerationID)
+}
+
+func TestManagerThreadsGenerationIDToCheckpoint(t *testing.T) {
+	var received checkpoint.AsyncRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&received)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	mgr := NewManager(Opts{
+		Mode: StepModeCheckpoint,
+		Fn: testFunction{config: fn.FunctionOpts{
+			Checkpoint: &checkpointpkg.Config{BatchSteps: 1},
+		}},
+		Request: &Request{CallCtx: CallCtx{
+			FunctionID:   uuid.New(),
+			RunID:        "run-123",
+			QueueItemRef: "qi-456",
+			GenerationID: 789,
+		}},
+		APIBaseURL: server.URL,
+	})
+
+	mgr.AppendOp(context.Background(), opcode.Step{
+		Op: enums.OpcodeStepRun,
+		ID: "step-1",
+	})
+
+	assert.Equal(t, 789, received.GenerationID)
+}
+
+func TestManagerStaleDispatchHijacksCheckpointExecution(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer server.Close()
+
+	var cancelled atomic.Bool
+	mgr := NewManager(Opts{
+		Mode: StepModeCheckpoint,
+		Fn: testFunction{config: fn.FunctionOpts{
+			Checkpoint: &checkpointpkg.Config{BatchSteps: 1},
+		}},
+		Request: &Request{CallCtx: CallCtx{
+			FunctionID:   uuid.New(),
+			RunID:        "run-123",
+			QueueItemRef: "qi-456",
+			GenerationID: 789,
+		}},
+		Cancel: func() {
+			cancelled.Store(true)
+		},
+		APIBaseURL: server.URL,
+	})
+
+	require.PanicsWithValue(t, ControlHijack{}, func() {
+		mgr.AppendOp(context.Background(), opcode.Step{
+			Op: enums.OpcodeStepRun,
+			ID: "step-1",
+		})
+	})
+	assert.True(t, cancelled.Load())
+	assert.Empty(t, mgr.Ops(),
+		"stale dispatch must leave no buffered ops; otherwise the recovered "+
+			"handler returns them and the executor chains further dispatches "+
+			"off the stale SDK's response (EXE-1552)")
+}

--- a/internal/sdkrequest/request.go
+++ b/internal/sdkrequest/request.go
@@ -34,6 +34,7 @@ type CallCtx struct {
 	Stack                     CallStack `json:"stack"`
 	Attempt                   int       `json:"attempt"`
 	QueueItemRef              string    `json:"qi_id"`
+	GenerationID              int       `json:"generation_id"`
 	MaxAttempts               *int      `json:"max_attempts"`
 }
 


### PR DESCRIPTION
## Related

[EXE-1552: HTTP timeout leads to duplicate steps with checkpointing](https://linear.app/inngest/issue/EXE-1552/http-timeout-leads-to-duplicate-steps-with-checkpointing)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR adds a `GenerationID` fence to the checkpoint path so that a stale (re-queued) dispatch can be detected via a 409 response and aborted cleanly, preventing EXE-1552 duplicate-step corruption. It also introduces `FnConcurrency` / `ConcurrencyLimits` alongside the existing `StepConcurrency` type.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 04a354fe5d01d1aad14684ad4ac616a092126786.</sup>
<!-- /MENDRAL_SUMMARY -->