### PR TITLE
Fix vendored inngestgo races

### DIFF
--- a/.changeset/fix-inngestgo-races.md
+++ b/.changeset/fix-inngestgo-races.md
@@ -1,0 +1,7 @@
+---
+---
+
+"inngestgo": patch
+---
+
+Fix race conditions in the streaming handler and connect heartbeat handling.

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,7 +25,7 @@ jobs:
           go-version: '1.24'
       - name: Lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.1.6
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.11.4
           ./bin/golangci-lint run --verbose
   test-linux-race:
     strategy:

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -226,24 +226,31 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 	readerLifetimeContext, cancelReaderLifetimeContext := context.WithCancel(ctx)
 	defer cancelReaderLifetimeContext()
 
-	var lastGatewayHeartbeatReceived time.Time
+	heartbeatReceived := make(chan struct{}, 1)
 	go func() {
 		// Wait until initial heartbeat was sent out
 		<-time.After(preparedConn.heartbeatInterval)
 
-		heartbeatReplyTicker := time.NewTicker(preparedConn.heartbeatInterval)
-		defer heartbeatReplyTicker.Stop()
+		heartbeatTimeout := 2 * preparedConn.heartbeatInterval
+		heartbeatReplyTimer := time.NewTimer(heartbeatTimeout)
+		defer heartbeatReplyTimer.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-heartbeatReplyTicker.C:
-				gracePeriod := 2 * preparedConn.heartbeatInterval
-				if lastGatewayHeartbeatReceived.Before(time.Now().Add(-gracePeriod)) {
-					// No heartbeat received in time!
-					h.logger.Error("did not receive gateway heartbeat in time")
-					cancelReaderLifetimeContext()
+			case <-heartbeatReceived:
+				if !heartbeatReplyTimer.Stop() {
+					select {
+					case <-heartbeatReplyTimer.C:
+					default:
+					}
 				}
+				heartbeatReplyTimer.Reset(heartbeatTimeout)
+			case <-heartbeatReplyTimer.C:
+				// No heartbeat received in time!
+				h.logger.Error("did not receive gateway heartbeat in time")
+				cancelReaderLifetimeContext()
+				return
 			}
 		}
 	}()
@@ -273,12 +280,16 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 				return errGatewayDraining
 			case connectproto.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST:
 				// Handle invoke in a non-blocking way to allow for other messages to be processed
+				msgCopy := msg
 				h.workerPool.Add(workerPoolMsg{
-					msg:          &msg,
+					msg:          &msgCopy,
 					preparedConn: preparedConn,
 				})
 			case connectproto.GatewayMessageType_GATEWAY_HEARTBEAT:
-				lastGatewayHeartbeatReceived = time.Now()
+				select {
+				case heartbeatReceived <- struct{}{}:
+				default:
+				}
 			case connectproto.GatewayMessageType_WORKER_REPLY_ACK:
 				if err := h.handleMessageReplyAck(&msg); err != nil {
 					h.logger.Error("could not handle message reply ack", "err", err)

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -229,7 +229,11 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 	heartbeatReceived := make(chan struct{}, 1)
 	go func() {
 		// Wait until initial heartbeat was sent out
-		<-time.After(preparedConn.heartbeatInterval)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(preparedConn.heartbeatInterval):
+		}
 
 		heartbeatTimeout := 2 * preparedConn.heartbeatInterval
 		heartbeatReplyTimer := time.NewTimer(heartbeatTimeout)

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -285,6 +285,9 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 			case connectproto.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST:
 				// Handle invoke in a non-blocking way to allow for other messages to be processed
 				msgCopy := msg
+				if len(msgCopy.Payload) > 0 {
+					msgCopy.Payload = append([]byte(nil), msgCopy.Payload...)
+				}
 				h.workerPool.Add(workerPoolMsg{
 					msg:          &msgCopy,
 					preparedConn: preparedConn,

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -284,9 +284,11 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 				return errGatewayDraining
 			case connectproto.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST:
 				// Handle invoke in a non-blocking way to allow for other messages to be processed
-				msgCopy := msg
-				if len(msgCopy.Payload) > 0 {
-					msgCopy.Payload = append([]byte(nil), msgCopy.Payload...)
+				msgCopy := connectproto.ConnectMessage{
+					Kind: msg.Kind,
+				}
+				if len(msg.Payload) > 0 {
+					msgCopy.Payload = append([]byte(nil), msg.Payload...)
 				}
 				h.workerPool.Add(workerPoolMsg{
 					msg:          &msgCopy,

--- a/handler.go
+++ b/handler.go
@@ -812,27 +812,62 @@ func (h *handler) invoke(w http.ResponseWriter, r *http.Request) error {
 	l := h.Logger.With("fn", fnID, "call_ctx", request.CallCtx)
 	l.Debug("calling function")
 
-	stream, streamCancel := context.WithCancel(context.Background())
-	if h.UseStreaming {
-		w.WriteHeader(201)
-		go func() {
-			for {
-				if stream.Err() != nil {
-					return
-				}
-				_, _ = w.Write([]byte(" "))
-				<-time.After(5 * time.Second)
-			}
-		}()
-	}
-
 	var stepID *string
 	if rawStepID := r.URL.Query().Get("stepId"); rawStepID != "" && rawStepID != "step" {
 		stepID = &rawStepID
 	}
 
-	// Invoke the function, then immediately stop the streaming buffer.
-	resp, ops, err := invoke(
+	var (
+		resp      any
+		ops       []sdkrequest.GeneratorOpcode
+		invokeErr error
+	)
+
+	if h.UseStreaming {
+		type invokeResult struct {
+			resp any
+			ops  []sdkrequest.GeneratorOpcode
+			err  error
+		}
+
+		w.WriteHeader(201)
+
+		results := make(chan invokeResult, 1)
+		go func() {
+			resp, ops, err := invoke(
+				r.Context(),
+				h.client,
+				mw,
+				fn,
+				h.GetSigningKey(),
+				h.GetSigningKeyFallback(),
+				request,
+				stepID,
+			)
+			results <- invokeResult{resp: resp, ops: ops, err: err}
+		}()
+
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case result := <-results:
+				resp, ops, invokeErr = result.resp, result.ops, result.err
+				goto handleResponse
+			case <-r.Context().Done():
+				invokeErr = r.Context().Err()
+				goto handleResponse
+			case <-ticker.C:
+				_, _ = w.Write([]byte(" "))
+				if flusher, ok := w.(http.Flusher); ok {
+					flusher.Flush()
+				}
+			}
+		}
+	}
+
+	resp, ops, invokeErr = invoke(
 		r.Context(),
 		h.client,
 		mw,
@@ -842,25 +877,25 @@ func (h *handler) invoke(w http.ResponseWriter, r *http.Request) error {
 		request,
 		stepID,
 	)
-	streamCancel()
 
 	// NOTE: When triggering step errors, we should have an OpcodeStepError
 	// within ops alongside an error.  We can safely ignore that error, as it's
 	// only used for checking whether the step used a NoRetryError or RetryAtError
 	//
 	// For that reason, we check those values first.
-	noRetry := sdkerrors.IsNoRetryError(err)
-	retryAt := sdkerrors.GetRetryAtTime(err)
+handleResponse:
+	noRetry := sdkerrors.IsNoRetryError(invokeErr)
+	retryAt := sdkerrors.GetRetryAtTime(invokeErr)
 
 	if len(ops) == 1 && ops[0].Op == enums.OpcodeStepError {
 		// Now we've handled error types we can ignore step
 		// errors safely.
-		err = nil
+		invokeErr = nil
 	}
 
 	// Handle OpcodeStepFailed for permanent step failures
 	if len(ops) == 1 && ops[0].Op == enums.OpcodeStepFailed {
-		err = nil
+		invokeErr = nil
 		noRetry = true
 	}
 
@@ -872,17 +907,17 @@ func (h *handler) invoke(w http.ResponseWriter, r *http.Request) error {
 	// 	if err != nil {
 	// 	     return err
 	// 	}
-	if sdkerrors.IsStepError(err) {
-		err = fmt.Errorf("unhandled step error: %s", err)
+	if sdkerrors.IsStepError(invokeErr) {
+		invokeErr = fmt.Errorf("unhandled step error: %s", invokeErr)
 		noRetry = true
 	}
 
 	if h.UseStreaming {
-		if err != nil {
+		if invokeErr != nil {
 			// TODO: Add retry-at.
 			return json.NewEncoder(w).Encode(StreamResponse{
 				StatusCode: 500,
-				Body:       fmt.Sprintf("error calling function: %s", err.Error()),
+				Body:       fmt.Sprintf("error calling function: %s", invokeErr.Error()),
 				NoRetry:    noRetry,
 				RetryAt:    retryAt,
 			})
@@ -907,9 +942,9 @@ func (h *handler) invoke(w http.ResponseWriter, r *http.Request) error {
 		w.Header().Add(HeaderKeyRetryAfter, retryAt.Format(time.RFC3339))
 	}
 
-	if err != nil {
-		l.Error("error calling function", "error", err)
-		return err
+	if invokeErr != nil {
+		l.Error("error calling function", "error", invokeErr)
+		return invokeErr
 	}
 
 	if len(ops) > 0 {

--- a/handler.go
+++ b/handler.go
@@ -850,14 +850,15 @@ func (h *handler) invoke(w http.ResponseWriter, r *http.Request) error {
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
 
-		for {
+		done := false
+		for !done {
 			select {
 			case result := <-results:
 				resp, ops, invokeErr = result.resp, result.ops, result.err
-				goto handleResponse
+				done = true
 			case <-r.Context().Done():
 				invokeErr = r.Context().Err()
-				goto handleResponse
+				done = true
 			case <-ticker.C:
 				_, _ = w.Write([]byte(" "))
 				if flusher, ok := w.(http.Flusher); ok {
@@ -865,25 +866,24 @@ func (h *handler) invoke(w http.ResponseWriter, r *http.Request) error {
 				}
 			}
 		}
+	} else {
+		resp, ops, invokeErr = invoke(
+			r.Context(),
+			h.client,
+			mw,
+			fn,
+			h.GetSigningKey(),
+			h.GetSigningKeyFallback(),
+			request,
+			stepID,
+		)
 	}
-
-	resp, ops, invokeErr = invoke(
-		r.Context(),
-		h.client,
-		mw,
-		fn,
-		h.GetSigningKey(),
-		h.GetSigningKeyFallback(),
-		request,
-		stepID,
-	)
 
 	// NOTE: When triggering step errors, we should have an OpcodeStepError
 	// within ops alongside an error.  We can safely ignore that error, as it's
 	// only used for checking whether the step used a NoRetryError or RetryAtError
 	//
 	// For that reason, we check those values first.
-handleResponse:
 	noRetry := sdkerrors.IsNoRetryError(invokeErr)
 	retryAt := sdkerrors.GetRetryAtTime(invokeErr)
 

--- a/handler_race_test.go
+++ b/handler_race_test.go
@@ -1,0 +1,76 @@
+package inngestgo
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStreamingInvoke_ResponseWriterRace exercises the streaming code path
+// in handler.go. The race is within a single request: the keepalive
+// goroutine and the main handler goroutine both write to
+// http.ResponseWriter, which isn't safe for concurrent use.
+//
+// Goal: overlap the 5-second keepalive tick with the JSON-encoding write
+// of the response. The function deliberately sleeps 5.2s so the keepalive
+// goroutine is mid-Write when the response Encoder runs.
+//
+// On the patched code, all writes happen on the handler goroutine; the
+// test passes clean under -race.
+//
+// The test also asserts the function is invoked exactly once. This catches
+// regressions where the streaming and non-streaming branches both run, as
+// happened in an early iteration of the fix.
+//
+// This test does not cover the connect/connection.go fix. That needs its
+// own test if direct regression coverage is wanted.
+func TestStreamingInvoke_ResponseWriterRace(t *testing.T) {
+	setEnvVars(t)
+	r := require.New(t)
+
+	c, err := NewClient(ClientOpts{
+		AppID:        "streaming-race-repro",
+		UseStreaming: true,
+	})
+	r.NoError(err)
+
+	event := EventA{
+		Name: "test/event.a",
+		Data: EventAData{Foo: "x", Bar: "y"},
+	}
+	result := map[string]any{"result": true}
+
+	var calls atomic.Int32
+
+	fn, err := CreateFunction(
+		c,
+		FunctionOpts{ID: "race-repro"},
+		EventTrigger("test/event.a", nil),
+		func(ctx context.Context, input Input[EventAData]) (any, error) {
+			calls.Add(1)
+			time.Sleep(5200 * time.Millisecond)
+			return result, nil
+		},
+	)
+	r.NoError(err)
+
+	server := httptest.NewServer(c.Serve())
+	defer server.Close()
+
+	q := url.Values{}
+	q.Add("fnId", fn.FullyQualifiedID())
+	urlStr := fmt.Sprintf("%s?%s", server.URL, q.Encode())
+
+	resp := handlerPost(t, urlStr, createRequest(t, event))
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(resp.Body)
+
+	r.Equal(int32(1), calls.Load(), "function should be invoked exactly once")
+}


### PR DESCRIPTION
This fixes two concurrency bugs in the `inngestgo` runtime:

 - handler.go: The HTTP response writer was being touched from multiple goroutines (the function invocation path and the streaming writer path), which isn't safe in Go. This PR:                                        
    - Keeps function invocation off the streaming writer entirely.                                                                                                           
    - Moves all response writes onto the handler goroutine.
    - Exits cleanly if the client disconnects while a streamed invocation is still running.                                                                                  
  
 - connect/connection.go
   - Heartbeat: replaced a shared timestamp (read and written across goroutines) with a channel-driven timeout loop.                                                        
   - Gateway messages: now copied before being handed to the worker pool, so workers don't share buffer state with the receiver.
            
Added a unit test to make sure the streaming path runs the user's function exactly once and doesn't write to the response from multiple goroutines at the same time.

  ## Why

  These code paths are used in production by Go SDK apps. The previous implementation could race concurrent HTTP writes in streaming mode and could also race on heartbeat tracking in the connect handler.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes two concurrency bugs in the inngestgo runtime: (1) the HTTP streaming handler now runs `invoke()` in a goroutine and serializes all response writes onto the handler goroutine, with clean disconnect handling via `r.Context().Done()`; (2) the connect heartbeat replaces a shared `time.Time` variable with a channel-driven timer loop, and gateway executor messages are deep-copied before being handed to the worker pool. A unit test and golangci-lint bump are also included.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit bb52a38b6b32676bbb6d1144d264c5aa33a6f5e8.</sup>
<!-- /MENDRAL_SUMMARY -->