### PR TITLE
fix: ignore stale connect lease acks

### DIFF
--- a/.changeset/ignore-stale-lease-acks.md
+++ b/.changeset/ignore-stale-lease-acks.md
@@ -1,0 +1,5 @@
+---
+"inngestgo": patch
+---
+
+Ignore stale Connect lease ACKs after a request has completed.

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -305,21 +305,9 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 					continue
 				}
 			case connectproto.GatewayMessageType_WORKER_REQUEST_EXTEND_LEASE_ACK:
-				{
-					var payload connectproto.WorkerRequestExtendLeaseAckData
-					if err := proto.Unmarshal(msg.Payload, &payload); err != nil {
-						h.logger.Error("could not parse extend lease ack", "err", err)
-						continue
-					}
-
-					h.workerPool.inProgressLeasesLock.Lock()
-					if payload.NewLeaseId != nil {
-						h.workerPool.inProgressLeases[payload.RequestId] = *payload.NewLeaseId
-					} else {
-						// remove local request lease to stop extending
-						delete(h.workerPool.inProgressLeases, payload.RequestId)
-					}
-					h.workerPool.inProgressLeasesLock.Unlock()
+				if err := h.handleWorkerRequestExtendLeaseAck(&msg); err != nil {
+					h.logger.Error("could not handle extend lease ack", "err", err)
+					continue
 				}
 			default:
 				h.logger.Debug("got unknown gateway request", "err", err)
@@ -430,6 +418,28 @@ func (h *connectHandler) handleMessageReplyAck(msg *connectproto.ConnectMessage)
 	}
 
 	h.messageBuffer.acknowledge(payload.RequestId)
+
+	return nil
+}
+
+func (h *connectHandler) handleWorkerRequestExtendLeaseAck(msg *connectproto.ConnectMessage) error {
+	var payload connectproto.WorkerRequestExtendLeaseAckData
+	if err := proto.Unmarshal(msg.Payload, &payload); err != nil {
+		return fmt.Errorf("could not unmarshal extend lease ack data: %w", err)
+	}
+
+	h.workerPool.inProgressLeasesLock.Lock()
+	defer h.workerPool.inProgressLeasesLock.Unlock()
+
+	if payload.NewLeaseId != nil {
+		if _, ok := h.workerPool.inProgressLeases[payload.RequestId]; !ok {
+			return nil
+		}
+		h.workerPool.inProgressLeases[payload.RequestId] = *payload.NewLeaseId
+	} else {
+		// remove local request lease to stop extending
+		delete(h.workerPool.inProgressLeases, payload.RequestId)
+	}
 
 	return nil
 }

--- a/connect/handler_test.go
+++ b/connect/handler_test.go
@@ -376,3 +376,70 @@ func TestMessageReadLimitWithProtobuf(t *testing.T) {
 		r.Equal(connectproto.GatewayMessageType_GATEWAY_HEARTBEAT, msg.Kind)
 	})
 }
+
+func TestHandleWorkerRequestExtendLeaseAck(t *testing.T) {
+	newLeaseID := "new-lease-id"
+
+	tests := []struct {
+		name           string
+		initialLeases  map[string]string
+		payload        *connectproto.WorkerRequestExtendLeaseAckData
+		expectedLeases map[string]string
+	}{
+		{
+			name: "updates existing request lease",
+			initialLeases: map[string]string{
+				"request-id": "old-lease-id",
+			},
+			payload: &connectproto.WorkerRequestExtendLeaseAckData{
+				RequestId:  "request-id",
+				NewLeaseId: &newLeaseID,
+			},
+			expectedLeases: map[string]string{
+				"request-id": "new-lease-id",
+			},
+		},
+		{
+			name: "removes request lease when ack has no new lease",
+			initialLeases: map[string]string{
+				"request-id": "old-lease-id",
+			},
+			payload: &connectproto.WorkerRequestExtendLeaseAckData{
+				RequestId: "request-id",
+			},
+			expectedLeases: map[string]string{},
+		},
+		{
+			name:          "ignores stale ack for completed request",
+			initialLeases: map[string]string{},
+			payload: &connectproto.WorkerRequestExtendLeaseAckData{
+				RequestId:  "request-id",
+				NewLeaseId: &newLeaseID,
+			},
+			expectedLeases: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+
+			payload, err := proto.Marshal(tt.payload)
+			r.NoError(err)
+
+			h := &connectHandler{
+				workerPool: &workerPool{
+					inProgressLeases: tt.initialLeases,
+				},
+			}
+
+			err = h.handleWorkerRequestExtendLeaseAck(&connectproto.ConnectMessage{
+				Kind:    connectproto.GatewayMessageType_WORKER_REQUEST_EXTEND_LEASE_ACK,
+				Payload: payload,
+			})
+			r.NoError(err)
+
+			r.Equal(tt.expectedLeases, h.workerPool.inProgressLeases)
+		})
+	}
+}


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Extracts lease ACK handling into `handleWorkerRequestExtendLeaseAck` and adds a guard to ignore stale ACKs: if the request ID is no longer tracked in `inProgressLeases` (i.e., the request already completed), the new lease ID is discarded rather than re-inserted.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b7dd1dbdfa707d9826d9c513701c13a340d04552.</sup>
<!-- /MENDRAL_SUMMARY -->