### PR TITLE
SYS-350: improve SDK logging

### DIFF
--- a/.changeset/log-connect-state-transitions.md
+++ b/.changeset/log-connect-state-transitions.md
@@ -2,4 +2,4 @@
 "inngestgo": patch
 ---
 
-Allow default SDK logging to be configured with `LOG_LEVEL` and `LOG_HANDLER`, and add Connect worker state transition logs with gateway connection context.
+Allow default SDK logging to be configured with `LOG_LEVEL` and `LOG_HANDLER`, default to a colorful dev logger, and add Connect worker state transition logs with gateway connection context.

--- a/.changeset/log-connect-state-transitions.md
+++ b/.changeset/log-connect-state-transitions.md
@@ -1,0 +1,5 @@
+---
+"inngestgo": patch
+---
+
+Allow default SDK logging to be configured with `LOG_LEVEL` and `LOG_HANDLER`, and add Connect worker state transition logs with gateway connection context.

--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/inngest/inngestgo/internal/logger"
 	"github.com/inngest/inngestgo/internal/middleware"
 	"github.com/inngest/inngestgo/pkg/checkpoint"
 	"github.com/inngest/inngestgo/pkg/env"
@@ -138,7 +139,7 @@ func NewClient(opts ClientOpts) (Client, error) {
 	}
 
 	if opts.Logger == nil {
-		opts.Logger = slog.Default()
+		opts.Logger = logger.Default()
 	}
 
 	// Add the default log middleware as the first middleware.

--- a/client_test.go
+++ b/client_test.go
@@ -1,9 +1,12 @@
 package inngestgo
 
 import (
+	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetEventKey(t *testing.T) {
@@ -41,4 +44,42 @@ func TestGetEventKey(t *testing.T) {
 		c := apiClient{}
 		assert.Equal(t, "NO_EVENT_KEY_SET", c.GetEventKey())
 	})
+}
+
+func TestNewClientUsesEnvConfiguredDefaultLogger(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "debug")
+	t.Setenv("LOG_HANDLER", "json")
+
+	c, err := NewClient(ClientOpts{AppID: "test"})
+	require.NoError(t, err)
+
+	opts := c.Options()
+	assert.True(t, opts.Logger.Enabled(context.Background(), slog.LevelDebug))
+	_, ok := opts.Logger.Handler().(*slog.JSONHandler)
+	assert.True(t, ok)
+}
+
+func TestNewClientUsesTextLoggerHandler(t *testing.T) {
+	t.Setenv("LOG_HANDLER", "txt")
+
+	c, err := NewClient(ClientOpts{AppID: "test"})
+	require.NoError(t, err)
+
+	opts := c.Options()
+	_, ok := opts.Logger.Handler().(*slog.TextHandler)
+	assert.True(t, ok)
+}
+
+func TestNewClientKeepsProvidedLogger(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "debug")
+	t.Setenv("LOG_HANDLER", "json")
+
+	provided := slog.New(slog.DiscardHandler)
+	c, err := NewClient(ClientOpts{
+		AppID:  "test",
+		Logger: provided,
+	})
+	require.NoError(t, err)
+
+	assert.Same(t, provided, c.Options().Logger)
 }

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -53,7 +53,7 @@ func (h *connectHandler) connect(ctx context.Context, data connectionEstablishDa
 	// Set up connection (including connect handshake protocol)
 	preparedConn, err := h.prepareConnection(ctx, data, o.excludeGateways)
 	if err != nil {
-		h.logger.Error("could not establish connection", "err", err)
+		h.logger.Error("could not establish connection", "err", err, "reconnect", shouldReconnect(err))
 
 		h.notifyConnectDoneChan <- connectReport{
 			reconnect: shouldReconnect(err),
@@ -61,6 +61,9 @@ func (h *connectHandler) connect(ctx context.Context, data connectionEstablishDa
 		}
 		return
 	}
+
+	l := h.logger.With(preparedConn.logAttrs()...)
+	l.Debug("connection established")
 
 	// Notify that the connection was established
 	h.notifyConnectedChan <- struct{}{}
@@ -74,7 +77,7 @@ func (h *connectHandler) connect(ctx context.Context, data connectionEstablishDa
 	// Set up connection lifecycle logic (receiving messages, handling requests, etc.)
 	err = h.handleConnection(h.workerCtx, data, preparedConn)
 	if err != nil {
-		h.logger.Error("could not handle connection", "err", err)
+		l.Error("could not handle connection", "err", err, "reconnect", shouldReconnect(err))
 
 		if errors.Is(err, errGatewayDraining) {
 			// if the gateway is draining, the original connection was closed, and we already reconnected inside handleConnection
@@ -103,10 +106,19 @@ type connectionEstablishData struct {
 type connection struct {
 	ws               *websocket.Conn
 	gatewayGroupName string
+	gatewayEndpoint  string
 	connectionId     string
 
 	heartbeatInterval   time.Duration
 	extendLeaseInterval time.Duration
+}
+
+func (c *connection) logAttrs() []any {
+	return []any{
+		"connection_id", c.connectionId,
+		"gateway_group", c.gatewayGroupName,
+		"gateway_endpoint", c.gatewayEndpoint,
+	}
 }
 
 func (h *connectHandler) prepareConnection(ctx context.Context, data connectionEstablishData, excludeGateways []string) (*connection, error) {
@@ -179,6 +191,7 @@ func (h *connectHandler) prepareConnection(ctx context.Context, data connectionE
 	return &connection{
 		ws:                  ws,
 		gatewayGroupName:    startRes.GetGatewayGroup(),
+		gatewayEndpoint:     gatewayHost.String(),
 		connectionId:        connectionId.String(),
 		heartbeatInterval:   heartbeatInterval,
 		extendLeaseInterval: extendLeaseInterval,
@@ -188,6 +201,8 @@ func (h *connectHandler) prepareConnection(ctx context.Context, data connectionE
 func (h *connectHandler) handleConnection(ctx context.Context, data connectionEstablishData, preparedConn *connection) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	l := h.logger.With(preparedConn.logAttrs()...)
 
 	defer func() {
 		// This is a fallback safeguard to always close the WebSocket connection at the end of the function
@@ -215,9 +230,9 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 					Kind: connectproto.GatewayMessageType_WORKER_HEARTBEAT,
 				})
 				if err != nil {
-					h.logger.Error("failed to send worker heartbeat", "err", err)
+					l.Error("failed to send worker heartbeat", "err", err, "heartbeat_interval", preparedConn.heartbeatInterval.String())
 				}
-				h.logger.Debug("sent worker heartbeat")
+				l.Debug("sent worker heartbeat", "heartbeat_interval", preparedConn.heartbeatInterval.String())
 			}
 
 		}
@@ -252,7 +267,7 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 				heartbeatReplyTimer.Reset(heartbeatTimeout)
 			case <-heartbeatReplyTimer.C:
 				// No heartbeat received in time!
-				h.logger.Error("did not receive gateway heartbeat in time")
+				l.Error("did not receive gateway heartbeat in time", "heartbeat_interval", preparedConn.heartbeatInterval.String(), "heartbeat_timeout", heartbeatTimeout.String())
 				cancelReaderLifetimeContext()
 				return
 			}
@@ -269,18 +284,19 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 			// - Gateway heartbeat was missed (unexpected connection loss)
 			err := wsproto.Read(readerLifetimeContext, preparedConn.ws, &msg)
 			if err != nil {
-				h.logger.Error("failed to read message", "err", err)
+				l.Error("failed to read message", "err", err, "reader_context_error", readerLifetimeContext.Err())
 
 				// The connection may still be active, but for some reason we couldn't read the message
 				return err
 			}
 
-			h.logger.Debug("received gateway request", "kind", msg.Kind.String())
+			l.Debug("received gateway request", "kind", msg.Kind.String())
 
 			switch msg.Kind {
 			case connectproto.GatewayMessageType_GATEWAY_CLOSING:
 				// Stop the read loop: We will not receive any further messages and should establish a new connection
 				// We can still use the old connection to send replies to the gateway
+				l.Info("gateway requested connection drain")
 				return errGatewayDraining
 			case connectproto.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST:
 				// Handle invoke in a non-blocking way to allow for other messages to be processed
@@ -301,22 +317,22 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 				}
 			case connectproto.GatewayMessageType_WORKER_REPLY_ACK:
 				if err := h.handleMessageReplyAck(&msg); err != nil {
-					h.logger.Error("could not handle message reply ack", "err", err)
+					l.Error("could not handle message reply ack", "err", err)
 					continue
 				}
 			case connectproto.GatewayMessageType_WORKER_REQUEST_EXTEND_LEASE_ACK:
 				if err := h.handleWorkerRequestExtendLeaseAck(&msg); err != nil {
-					h.logger.Error("could not handle extend lease ack", "err", err)
+					l.Error("could not handle extend lease ack", "err", err)
 					continue
 				}
 			default:
-				h.logger.Debug("got unknown gateway request", "err", err)
+				l.Debug("got unknown gateway request", "err", err)
 				continue
 			}
 		}
 	})
 
-	h.logger.Debug("waiting for read loop to end")
+	l.Debug("waiting for read loop to end")
 
 	// If read loop ends, this can be for two reasons
 	// - Connection loss (io.EOF), read loop terminated intentionally (CloseError), other error (unexpected), missed heartbeat (readerLifetimeContext canceled)
@@ -341,7 +357,7 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 			// Wait until the new connection is established before closing the old one
 			<-waitUntilConnected.Done()
 			if errors.Is(waitUntilConnected.Err(), context.DeadlineExceeded) {
-				h.logger.Error("timed out waiting for new connection to be established")
+				l.Error("timed out waiting for new connection to be established")
 			}
 
 			// Send a proper close frame
@@ -350,12 +366,12 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 			return errGatewayDraining
 		}
 
-		h.logger.Debug("read loop ended with error", "err", err)
+		l.Debug("read loop ended with error", "err", err)
 
 		// In case the gateway intentionally closed the connection, we'll receive a close error
 		cerr := websocket.CloseError{}
 		if errors.As(err, &cerr) {
-			h.logger.Error("connection closed with reason", "reason", cerr.Reason)
+			l.Error("connection closed with reason", "reason", cerr.Reason)
 
 			// Reconnect!
 			return newReconnectErr(fmt.Errorf("connection closed with reason %q: %w", cerr.Reason, cerr))
@@ -363,7 +379,7 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 
 		// connection closed without reason
 		if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
-			h.logger.Error("failed to read message from gateway, lost connection unexpectedly", "err", err)
+			l.Error("failed to read message from gateway, lost connection unexpectedly", "err", err)
 			return newReconnectErr(fmt.Errorf("connection closed unexpectedly: %w", cerr))
 		}
 
@@ -380,17 +396,17 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 
 	// Signal gateway that we won't process additional messages!
 	{
-		h.logger.Debug("sending worker pause message")
+		l.Debug("sending worker pause message")
 		err := wsproto.Write(context.Background(), preparedConn.ws, &connectproto.ConnectMessage{
 			Kind: connectproto.GatewayMessageType_WORKER_PAUSE,
 		})
 		if err != nil {
 			// We should not exit here, as we're already in the shutdown routine
-			h.logger.Error("failed to serialize worker pause msg", "err", err)
+			l.Error("failed to serialize worker pause msg", "err", err)
 		}
 	}
 
-	h.logger.Debug("waiting for in-progress requests to finish")
+	l.Debug("waiting for in-progress requests to finish")
 
 	// Wait until all in-progress requests are completed
 	h.workerPool.Wait()
@@ -402,11 +418,11 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 	if h.messageBuffer.hasMessages() {
 		err := h.messageBuffer.flush(data.hashedSigningKey)
 		if err != nil {
-			h.logger.Error("could not send buffered messages", "err", err)
+			l.Error("could not send buffered messages", "err", err)
 		}
 	}
 
-	h.logger.Debug("connection done")
+	l.Debug("connection done")
 
 	return nil
 }

--- a/connect/handler.go
+++ b/connect/handler.go
@@ -264,6 +264,10 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 
 				if !msg.reconnect {
 					h.setState(ConnectionStateClosed, "connection ended without reconnect", "err", msg.err)
+					err := msg.err
+					if err == nil {
+						err = fmt.Errorf("connection ended without reconnect")
+					}
 
 					if isInitialConnection {
 						isInitialConnection = false
@@ -280,8 +284,9 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 					if errors.Is(msg.err, ErrTooManyConnections) {
 						// If limits are exceed in initial connection, return immediately
 						if isInitialConnection {
+							err := fmt.Errorf("too many connections, please disconnect other workers or upgrade your billing plan for more concurrent connections")
 							isInitialConnection = false
-							initialConnectionDone <- fmt.Errorf("too many connections, please disconnect other workers or upgrade your billing plan for more concurrent connections")
+							initialConnectionDone <- err
 							return err
 						}
 					}

--- a/connect/handler.go
+++ b/connect/handler.go
@@ -179,6 +179,8 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 	startCtx, cancelStart := context.WithTimeout(ctx, time.Second*30)
 	defer cancelStart()
 
+	l := h.logger
+
 	signingKey := h.opts.HashedSigningKey
 	if len(signingKey) == 0 && !h.opts.IsDev {
 		return nil, fmt.Errorf("hashed signing key is required")
@@ -217,7 +219,7 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 		}
 	}
 
-	h.logger.Debug("using provided functions", "slugs", appSlugs)
+	l.Debug("using provided functions", "slugs", appSlugs)
 
 	marshaledCapabilities, err := json.Marshal(h.opts.Capabilities)
 	if err != nil {
@@ -243,7 +245,7 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 
 			// Reset attempts when connection succeeded
 			case <-h.notifyConnectedChan:
-				h.logger.Debug("connected")
+				l.Debug("connected")
 				if isInitialConnection {
 					isInitialConnection = false
 					initialConnectionDone <- nil
@@ -254,7 +256,7 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 
 			// Handle connection done events
 			case msg := <-h.notifyConnectDoneChan:
-				h.logger.Error("connect failed", "err", err, "reconnect", msg.reconnect)
+				l.Error("connect failed", "err", msg.err, "reconnect", msg.reconnect)
 
 				if !msg.reconnect {
 					h.setState(ConnectionStateClosed)
@@ -335,14 +337,14 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 				if h.messageBuffer.hasMessages() {
 					err := h.messageBuffer.flush(h.auth.hashedSigningKey)
 					if err != nil {
-						h.logger.Error("could not send buffered messages", "err", err)
+						l.Error("could not send buffered messages", "err", err)
 					}
 				}
 
 				// continue to reconnect logic
 				delay := expBackoff(attempts)
 
-				h.logger.Debug("reconnecting", "delay", delay.String(), "attempts", attempts)
+				l.Debug("reconnecting", "delay", delay.String(), "attempts", attempts)
 
 				select {
 				case <-time.After(delay):
@@ -353,7 +355,7 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 						initialConnectionDone <- nil
 					}
 
-					h.logger.Info("canceled context while waiting to reconnect")
+					l.Info("canceled context while waiting to reconnect")
 					return nil
 				}
 
@@ -394,18 +396,18 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 		// Wait for run loop to complete (maximum attempts reached, context canceled)
 		runLoopErr := runLoop.Wait()
 		if runLoopErr != nil {
-			h.logger.Error("could not connect", "err", runLoopErr)
+			l.Error("could not connect", "err", runLoopErr)
 		}
 
-		h.logger.Debug("run loop ended")
+		l.Debug("run loop ended")
 
 		// Wait until current connection is fully terminated
 		select {
 		case <-ctx.Done():
 		case <-time.After(5 * time.Second):
-			h.logger.Warn("shutting down without final signal")
+			l.Warn("shutting down without final signal")
 		case <-h.notifyConnectDoneChan:
-			h.logger.Debug("got connection done signal")
+			l.Debug("got connection done signal")
 		}
 
 		// Always send out buffered messages using API
@@ -413,13 +415,13 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 			// Send buffered messages
 			err := h.messageBuffer.flush(h.auth.hashedSigningKey)
 			if err != nil {
-				h.logger.Error("could not send buffered messages", "err", err)
+				l.Error("could not send buffered messages", "err", err)
 			}
 
 			// TODO Push remaining messages to another destination for processing?
 		}
 
-		h.logger.Debug("connect handler done")
+		l.Debug("connect handler done")
 		return nil
 	})
 

--- a/connect/handler.go
+++ b/connect/handler.go
@@ -250,16 +250,20 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 					isInitialConnection = false
 					initialConnectionDone <- nil
 				}
-				h.setState(ConnectionStateActive)
+				h.setState(ConnectionStateActive, "connection established", "attempt", attempts)
 				attempts = 0
 				continue
 
 			// Handle connection done events
 			case msg := <-h.notifyConnectDoneChan:
-				l.Error("connect failed", "err", msg.err, "reconnect", msg.reconnect)
+				if msg.err != nil {
+					l.Error("connection ended with error", "err", msg.err, "reconnect", msg.reconnect)
+				} else {
+					l.Debug("connection ended", "reconnect", msg.reconnect)
+				}
 
 				if !msg.reconnect {
-					h.setState(ConnectionStateClosed)
+					h.setState(ConnectionStateClosed, "connection ended without reconnect", "err", msg.err)
 
 					if isInitialConnection {
 						isInitialConnection = false
@@ -269,7 +273,7 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 					return err
 				}
 
-				h.setState(ConnectionStateReconnecting)
+				h.setState(ConnectionStateReconnecting, "connection ended with reconnect", "err", msg.err, "attempt", attempts)
 
 				// Some errors should be handled differently (e.g. auth failed)
 				if msg.err != nil {
@@ -446,13 +450,17 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 func (h *connectHandler) Close() error {
 	// If connection was already closed, this is a no-op.
 	if h.closed.Swap(true) {
+		h.logger.Debug("close ignored; connection already closed", "state", h.State())
 		return nil
 	}
 
 	if h.cancelWorkerCtx == nil {
-		return fmt.Errorf("connection was not fully set up")
+		err := fmt.Errorf("connection was not fully set up")
+		h.logger.Error("could not close connection", "err", err, "state", h.State())
+		return err
 	}
 
+	h.setState(ConnectionStateClosing, "close requested")
 	h.cancelWorkerCtx()
 
 	// Wait until connection loop finishes
@@ -461,7 +469,7 @@ func (h *connectHandler) Close() error {
 		return fmt.Errorf("failed to connect: %w", err)
 	}
 
-	h.setState(ConnectionStateClosed)
+	h.setState(ConnectionStateClosed, "close complete")
 
 	return nil
 }
@@ -472,10 +480,19 @@ func (h *connectHandler) State() ConnectionState {
 	return h.state
 }
 
-func (h *connectHandler) setState(state ConnectionState) {
+func (h *connectHandler) setState(state ConnectionState, reason string, attrs ...any) {
 	h.stateLock.Lock()
-	defer h.stateLock.Unlock()
+	previous := h.state
 	h.state = state
+	h.stateLock.Unlock()
+
+	logAttrs := []any{
+		"from", previous,
+		"to", state,
+		"reason", reason,
+	}
+	logAttrs = append(logAttrs, attrs...)
+	h.logger.Debug("worker connection state transition", logAttrs...)
 }
 
 var errGatewayDraining = errors.New("gateway is draining")

--- a/connect/handler.go
+++ b/connect/handler.go
@@ -58,8 +58,10 @@ func Connect(ctx context.Context, opts Opts, invokers map[string]FunctionInvoker
 	// Once the worker is running, it can only be stopped by calling Close()
 	doneCtx, cancelDone := context.WithCancel(context.Background())
 
+	l := logger.With("mode", "connect")
+
 	ch := &connectHandler{
-		logger:                 logger,
+		logger:                 l,
 		invokers:               invokers,
 		opts:                   opts,
 		notifyConnectDoneChan:  make(chan connectReport),
@@ -84,6 +86,7 @@ func Connect(ctx context.Context, opts Opts, invokers map[string]FunctionInvoker
 
 	conn, err := ch.Connect(ctx)
 	if err != nil {
+		l.Error("could not establish connection", "error", err)
 		return nil, fmt.Errorf("could not establish connection: %w", err)
 	}
 

--- a/connect/handler_test.go
+++ b/connect/handler_test.go
@@ -2,6 +2,7 @@ package connect
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -107,6 +108,75 @@ func TestMaxWorkerConcurrency(t *testing.T) {
 		// Should return default value when env var is invalid
 		r.Equal(defaultMaxWorkerConcurrency, *result)
 	})
+}
+
+func TestConnectReturnsNonReconnectError(t *testing.T) {
+	r := require.New(t)
+	expected := errors.New("connection failed")
+	h := &connectHandler{
+		opts:                   Opts{IsDev: true},
+		logger:                 slog.Default(),
+		notifyConnectDoneChan:  make(chan connectReport),
+		notifyConnectedChan:    make(chan struct{}),
+		initiateConnectionChan: make(chan struct{}, 1),
+		messageBuffer:          &messageBuffer{},
+		state:                  ConnectionStateConnecting,
+	}
+	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())
+	defer h.cancelWorkerCtx()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := h.Connect(context.Background())
+		done <- err
+	}()
+
+	h.notifyConnectDoneChan <- connectReport{
+		err:       expected,
+		reconnect: false,
+	}
+
+	select {
+	case err := <-done:
+		r.Error(err)
+		r.ErrorIs(err, expected)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Connect to return")
+	}
+}
+
+func TestConnectReturnsTooManyConnectionsError(t *testing.T) {
+	r := require.New(t)
+	h := &connectHandler{
+		opts:                   Opts{IsDev: true},
+		logger:                 slog.Default(),
+		notifyConnectDoneChan:  make(chan connectReport),
+		notifyConnectedChan:    make(chan struct{}),
+		initiateConnectionChan: make(chan struct{}, 1),
+		messageBuffer:          &messageBuffer{},
+		state:                  ConnectionStateConnecting,
+	}
+	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())
+	defer h.cancelWorkerCtx()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := h.Connect(context.Background())
+		done <- err
+	}()
+
+	h.notifyConnectDoneChan <- connectReport{
+		err:       ErrTooManyConnections,
+		reconnect: true,
+	}
+
+	select {
+	case err := <-done:
+		r.Error(err)
+		r.Contains(err.Error(), "too many connections")
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Connect to return")
+	}
 }
 
 func TestMessageReadLimit(t *testing.T) {

--- a/connect/handler_test.go
+++ b/connect/handler_test.go
@@ -147,13 +147,15 @@ func TestConnectReturnsNonReconnectError(t *testing.T) {
 
 func TestConnectReturnsTooManyConnectionsError(t *testing.T) {
 	r := require.New(t)
+	apiClient := newWorkerApiClient("", nil)
 	h := &connectHandler{
 		opts:                   Opts{IsDev: true},
 		logger:                 slog.Default(),
 		notifyConnectDoneChan:  make(chan connectReport),
 		notifyConnectedChan:    make(chan struct{}),
 		initiateConnectionChan: make(chan struct{}, 1),
-		messageBuffer:          &messageBuffer{},
+		apiClient:              apiClient,
+		messageBuffer:          newMessageBuffer(apiClient, slog.Default()),
 		state:                  ConnectionStateConnecting,
 	}
 	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())

--- a/connect/handler_test.go
+++ b/connect/handler_test.go
@@ -113,13 +113,15 @@ func TestMaxWorkerConcurrency(t *testing.T) {
 func TestConnectReturnsNonReconnectError(t *testing.T) {
 	r := require.New(t)
 	expected := errors.New("connection failed")
+	apiClient := newWorkerApiClient("", nil)
 	h := &connectHandler{
 		opts:                   Opts{IsDev: true},
 		logger:                 slog.Default(),
 		notifyConnectDoneChan:  make(chan connectReport),
 		notifyConnectedChan:    make(chan struct{}),
 		initiateConnectionChan: make(chan struct{}, 1),
-		messageBuffer:          &messageBuffer{},
+		apiClient:              apiClient,
+		messageBuffer:          newMessageBuffer(apiClient, slog.Default()),
 		state:                  ConnectionStateConnecting,
 	}
 	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())
@@ -169,7 +171,7 @@ func TestConnectReturnsTooManyConnectionsError(t *testing.T) {
 
 	h.notifyConnectDoneChan <- connectReport{
 		err:       ErrTooManyConnections,
-		reconnect: true,
+		reconnect: false,
 	}
 
 	select {

--- a/handler.go
+++ b/handler.go
@@ -289,14 +289,15 @@ func (h *handler) GetFunctions() []ServableFunction {
 }
 
 func (h *handler) SetOptions(opts handlerOpts) *handler {
-	h.handlerOpts = opts
-
 	if opts.MaxBodySize == 0 {
 		opts.MaxBodySize = DefaultMaxBodySize
 	}
 	if opts.Logger == nil {
 		opts.Logger = logger.Default()
 	}
+
+	opts.Logger = opts.Logger.With("mode", "serve")
+	h.handlerOpts = opts
 
 	return h
 }

--- a/handler.go
+++ b/handler.go
@@ -255,6 +255,8 @@ func newHandler(c Client, opts handlerOpts) *handler {
 		opts.MaxBodySize = DefaultMaxBodySize
 	}
 
+	opts.Logger = opts.Logger.With("mode", "serve")
+
 	return &handler{
 		handlerOpts: opts,
 		appName:     c.AppID(),

--- a/handler.go
+++ b/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/inngest/inngestgo/internal"
 	"github.com/inngest/inngestgo/internal/event"
 	"github.com/inngest/inngestgo/internal/fn"
+	"github.com/inngest/inngestgo/internal/logger"
 	"github.com/inngest/inngestgo/internal/middleware"
 	"github.com/inngest/inngestgo/internal/sdkrequest"
 	"github.com/inngest/inngestgo/internal/types"
@@ -248,7 +249,7 @@ func (h handlerOpts) isDev() bool {
 // newHandler returns a new Handler for serving Inngest functions.
 func newHandler(c Client, opts handlerOpts) *handler {
 	if opts.Logger == nil {
-		opts.Logger = slog.Default()
+		opts.Logger = logger.Default()
 	}
 
 	if opts.MaxBodySize == 0 {
@@ -294,7 +295,7 @@ func (h *handler) SetOptions(opts handlerOpts) *handler {
 		opts.MaxBodySize = DefaultMaxBodySize
 	}
 	if opts.Logger == nil {
-		opts.Logger = slog.Default()
+		opts.Logger = logger.Default()
 	}
 
 	return h

--- a/handler_test.go
+++ b/handler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/syscode"
 	ifn "github.com/inngest/inngestgo/internal/fn"
+	"github.com/inngest/inngestgo/internal/logger"
 	"github.com/inngest/inngestgo/internal/middleware"
 	"github.com/inngest/inngestgo/internal/sdkrequest"
 	"github.com/inngest/inngestgo/step"
@@ -30,6 +31,20 @@ func setEnvVars(t *testing.T) {
 	t.Setenv("INNGEST_EVENT_KEY", "abc123")
 	t.Setenv("INNGEST_SIGNING_KEY", string(testKey))
 	t.Setenv("INNGEST_SIGNING_KEY_FALLBACK", string(testKeyFallback))
+}
+
+func TestHandlerSetOptionsAnnotatesServeMode(t *testing.T) {
+	t.Setenv("LOG_HANDLER", "txt")
+
+	var buf bytes.Buffer
+	h := &handler{}
+
+	h.SetOptions(handlerOpts{
+		Logger: logger.New(&buf),
+	})
+	h.Logger.Info("test log")
+
+	assert.Contains(t, buf.String(), "mode=serve")
 }
 
 type EventA = GenericEvent[EventAData]

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/lmittmann/tint"
 )
 
 const (
@@ -22,18 +24,43 @@ func Default() *slog.Logger {
 // New returns a slog logger configured from environment variables and writing
 // to w. It is exported for tests and internal packages that need custom writers.
 func New(w io.Writer) *slog.Logger {
-	opts := &slog.HandlerOptions{
+	handlerOpts := &slog.HandlerOptions{
 		Level: parseLevel(os.Getenv("LOG_LEVEL")),
 	}
 
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("LOG_HANDLER"))) {
 	case "json":
-		return slog.New(slog.NewJSONHandler(w, opts))
-	case "txt", "text", "":
-		return slog.New(slog.NewTextHandler(w, opts))
+		return slog.New(slog.NewJSONHandler(w, handlerOpts))
+	case "txt", "text":
+		return slog.New(slog.NewTextHandler(w, handlerOpts))
+	case "dev", "":
+		return slog.New(devHandler(w, handlerOpts.Level))
 	default:
-		return slog.New(slog.NewTextHandler(w, opts))
+		return slog.New(devHandler(w, handlerOpts.Level))
 	}
+}
+
+func devHandler(w io.Writer, level slog.Leveler) slog.Handler {
+	return tint.NewHandler(w, &tint.Options{
+		Level:      level,
+		TimeFormat: "[15:04:05.000]",
+		ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
+			if attr.Key == slog.LevelKey && len(groups) == 0 {
+				lvl, ok := attr.Value.Any().(slog.Level)
+				if ok {
+					switch lvl {
+					case LevelTrace:
+						return tint.Attr(13, slog.String(attr.Key, "TRC"))
+					case slog.LevelDebug:
+						return tint.Attr(3, slog.String(attr.Key, "DBG"))
+					case slog.LevelInfo:
+						return tint.Attr(14, slog.String(attr.Key, "INF"))
+					}
+				}
+			}
+			return attr
+		},
+	})
 }
 
 func parseLevel(value string) slog.Level {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,57 @@
+package logger
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	// LevelTrace matches the common slog convention of placing trace below debug.
+	LevelTrace slog.Level = -8
+)
+
+// Default returns the SDK's default slog logger, configured from environment
+// variables.
+func Default() *slog.Logger {
+	return New(os.Stderr)
+}
+
+// New returns a slog logger configured from environment variables and writing
+// to w. It is exported for tests and internal packages that need custom writers.
+func New(w io.Writer) *slog.Logger {
+	opts := &slog.HandlerOptions{
+		Level: parseLevel(os.Getenv("LOG_LEVEL")),
+	}
+
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("LOG_HANDLER"))) {
+	case "json":
+		return slog.New(slog.NewJSONHandler(w, opts))
+	case "txt", "text", "":
+		return slog.New(slog.NewTextHandler(w, opts))
+	default:
+		return slog.New(slog.NewTextHandler(w, opts))
+	}
+}
+
+func parseLevel(value string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "trace":
+		return LevelTrace
+	case "debug":
+		return slog.LevelDebug
+	case "info", "":
+		return slog.LevelInfo
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		if n, err := strconv.Atoi(value); err == nil {
+			return slog.Level(n)
+		}
+		return slog.LevelInfo
+	}
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -48,6 +48,32 @@ func TestNewUsesJSONHandler(t *testing.T) {
 	assert.Equal(t, float64(42), entry["answer"])
 }
 
+func TestNewUsesDevHandlerByDefault(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "info")
+	t.Setenv("LOG_HANDLER", "")
+
+	var buf bytes.Buffer
+	logger := New(&buf)
+	logger.Info("dev message")
+
+	assert.Contains(t, buf.String(), "dev message")
+	assert.Contains(t, buf.String(), "\x1b[")
+	assert.NotContains(t, buf.String(), "msg=\"dev message\"")
+	assert.NotContains(t, buf.String(), "{\"")
+}
+
+func TestNewUsesDevHandler(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "debug")
+	t.Setenv("LOG_HANDLER", "dev")
+
+	var buf bytes.Buffer
+	logger := New(&buf)
+	logger.Debug("dev debug")
+
+	assert.Contains(t, buf.String(), "dev debug")
+	assert.Contains(t, buf.String(), "\x1b[")
+}
+
 func TestNewUsesTextHandler(t *testing.T) {
 	t.Setenv("LOG_LEVEL", "info")
 	t.Setenv("LOG_HANDLER", "txt")

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,61 @@
+package logger
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewUsesLogLevel(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "debug")
+	t.Setenv("LOG_HANDLER", "txt")
+
+	var buf bytes.Buffer
+	logger := New(&buf)
+	logger.Debug("debug message")
+
+	assert.Contains(t, buf.String(), "debug message")
+}
+
+func TestNewFiltersByLogLevel(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "error")
+	t.Setenv("LOG_HANDLER", "txt")
+
+	var buf bytes.Buffer
+	logger := New(&buf)
+	logger.Warn("warn message")
+	logger.Error("error message")
+
+	assert.NotContains(t, buf.String(), "warn message")
+	assert.Contains(t, buf.String(), "error message")
+}
+
+func TestNewUsesJSONHandler(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "info")
+	t.Setenv("LOG_HANDLER", "json")
+
+	var buf bytes.Buffer
+	logger := New(&buf)
+	logger.Info("json message", "answer", 42)
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+	assert.Equal(t, "json message", entry[slog.MessageKey])
+	assert.Equal(t, float64(42), entry["answer"])
+}
+
+func TestNewUsesTextHandler(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "info")
+	t.Setenv("LOG_HANDLER", "txt")
+
+	var buf bytes.Buffer
+	logger := New(&buf)
+	logger.Info("text message")
+
+	assert.Contains(t, buf.String(), "msg=\"text message\"")
+	assert.NotContains(t, buf.String(), "{\"")
+}

--- a/internal/middleware/log.go
+++ b/internal/middleware/log.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"sync/atomic"
+
+	"github.com/inngest/inngestgo/internal/logger"
 )
 
 type logContextKeyType struct{}
@@ -15,13 +17,13 @@ func LoggerFromContext(ctx context.Context) *slog.Logger {
 	value := ctx.Value(logContextKey)
 	if value == nil {
 		// Unreachable if the middleware is used correctly.
-		return slog.Default()
+		return logger.Default()
 	}
 
 	l, ok := value.(*slog.Logger)
 	if !ok {
 		// Unreachable if the middleware is used correctly.
-		return slog.Default()
+		return logger.Default()
 	}
 
 	return l

--- a/internal/sdkrequest/manager.go
+++ b/internal/sdkrequest/manager.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"slices"
 	"sync"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/inngest/inngestgo/experimental"
 	"github.com/inngest/inngestgo/internal/checkpoint"
 	"github.com/inngest/inngestgo/internal/fn"
+	"github.com/inngest/inngestgo/internal/logger"
 	"github.com/inngest/inngestgo/internal/middleware"
 	"github.com/inngest/inngestgo/internal/opcode"
 	"github.com/inngest/inngestgo/internal/util"
@@ -304,7 +304,7 @@ func (r *requestCtxManager) AppendOp(ctx context.Context, op GeneratorOpcode) {
 				}
 				return
 			}
-			slog.Default().Warn("error checkpointing state, falling back to async response", "error", err)
+			logger.Default().Warn("error checkpointing state, falling back to async response", "error", err)
 		})
 	default:
 		// Do nothing else.

--- a/signature.go
+++ b/signature.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"log/slog"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -14,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gowebpki/jcs"
+	"github.com/inngest/inngestgo/internal/logger"
 )
 
 var (
@@ -33,7 +33,7 @@ func Sign(ctx context.Context, at time.Time, key, body []byte) (string, error) {
 	if len(body) > 0 {
 		body, err = jcs.Transform(body)
 		if err != nil {
-			slog.Default().Warn("failed to canonicalize body", "error", err)
+			logger.Default().Warn("failed to canonicalize body", "error", err)
 		}
 	}
 

--- a/stephttp/provider.go
+++ b/stephttp/provider.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/inngest/inngestgo/internal/logger"
 	"github.com/inngest/inngestgo/internal/middleware"
 	"github.com/inngest/inngestgo/pkg/env"
 )
@@ -112,7 +113,7 @@ func Setup(opts SetupOpts) *provider {
 		opts:     opts,
 		mw:       mw,
 		inflight: &atomic.Int32{},
-		logger:   slog.Default(),
+		logger:   logger.Default(),
 	}
 
 	p.api = NewAPIClient(p.opts.baseURL(), p.opts.signingKey(), p.opts.signingKeyFallback())


### PR DESCRIPTION
## Summary
- Configure the default SDK logger from `LOG_LEVEL` and `LOG_HANDLER` when no explicit logger is provided.
- Default SDK logging to a colorful `dev` handler, matching the upstream logger behavior, while keeping `LOG_HANDLER=json`, `txt`, and `text` available.
- Add Connect worker state transition logs with reasons for transitions.
- Add connection-scoped gateway context to Connect lifecycle, heartbeat, drain, and read-loop logs.
- Add a Changeset for the patch release.

## Testing
- `go test ./...`
- `go test ./connect`
- `go test ./internal/logger ./`

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds environment-variable-driven logger configuration (`LOG_LEVEL`, `LOG_HANDLER`) with a colorful `tint`-based dev handler as the default, replaces all `slog.Default()` calls with `logger.Default()`, annotates Connect and serve handlers with a `mode` attribute, and enriches Connect lifecycle/heartbeat/drain/read-loop logs with per-connection gateway context. State transitions now log the previous→next state with a reason string.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 07d77ae49154dec9464560cac633f92b1d1b5680.</sup>
<!-- /MENDRAL_SUMMARY -->