### PR TITLE
EXE-1802: Fix reporting synchronous durable endpoints runs

### DIFF
--- a/.changeset/stephttp-api-result-shape.md
+++ b/.changeset/stephttp-api-result-shape.md
@@ -1,0 +1,5 @@
+---
+"inngestgo": patch
+---
+
+Align `stephttp` `APIResult` wire format with the JS SDK: rename `status_code` to `status`, emit `body` as a string instead of base64-encoded bytes, and stop wrapping the run-complete payload in a `data` envelope.

--- a/stephttp/api_client.go
+++ b/stephttp/api_client.go
@@ -103,8 +103,8 @@ type NewAPIRunData struct {
 
 // APIResult represents the final result of an API function call
 type APIResult struct {
-	// StatusCode represents the status code for the API result
-	StatusCode int `json:"status"`
+	// Status represents the status code for the API result
+	Status int `json:"status"`
 	// Headers represents any response headers sent in the server response
 	Headers map[string]string `json:"headers"`
 	// Body represents the API response.  This may be empty by default.  It is

--- a/stephttp/api_client.go
+++ b/stephttp/api_client.go
@@ -104,12 +104,13 @@ type NewAPIRunData struct {
 // APIResult represents the final result of an API function call
 type APIResult struct {
 	// StatusCode represents the status code for the API result
-	StatusCode int `json:"status_code"`
+	StatusCode int `json:"status"`
 	// Headers represents any response headers sent in the server response
 	Headers map[string]string `json:"headers"`
-	// Body represents the API response.  This may be nil by default.  It is only
-	// captured when you manually specify that you want to track the result.
-	Body []byte `json:"body,omitempty"`
+	// Body represents the API response.  This may be empty by default.  It is
+	// only captured when you manually specify that you want to track the
+	// result.
+	Body string `json:"body,omitempty"`
 	// Duration represents the duration
 	Duration time.Duration `json:"duration"`
 	// Error represents any error from the API.  This is only for internal errors,

--- a/stephttp/api_client_test.go
+++ b/stephttp/api_client_test.go
@@ -17,9 +17,9 @@ import (
 // TestAPIResult_JSONShape validates wire format of the RunComplete payload.
 func TestAPIResult_JSONShape(t *testing.T) {
 	res := APIResult{
-		StatusCode: 200,
-		Headers:    map[string]string{"Content-Type": "application/json"},
-		Body:       `{"id":"user_1","name":"alice"}`,
+		Status:  200,
+		Headers: map[string]string{"Content-Type": "application/json"},
+		Body:    `{"id":"user_1","name":"alice"}`,
 	}
 
 	got, err := json.Marshal(res)

--- a/stephttp/api_client_test.go
+++ b/stephttp/api_client_test.go
@@ -2,13 +2,39 @@ package stephttp
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// TestAPIResult_JSONShape validates wire format of the RunComplete payload.
+func TestAPIResult_JSONShape(t *testing.T) {
+	res := APIResult{
+		StatusCode: 200,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       `{"id":"user_1","name":"alice"}`,
+	}
+
+	got, err := json.Marshal(res)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(got, &decoded), "raw=%s", got)
+
+	assert.NotContains(t, decoded, "status_code", "expected `status` field, got `status_code`: %s", got)
+	assert.Equal(t, float64(200), decoded["status"], "raw=%s", got)
+
+	body, ok := decoded["body"].(string)
+	require.True(t, ok, "expected body to be a string, got %T", decoded["body"])
+	assert.Equal(t, `{"id":"user_1","name":"alice"}`, body, "expected raw UTF-8 body, not base64")
+}
 
 func TestAPIClient_RetryLogic(t *testing.T) {
 	var callCount atomic.Int32

--- a/stephttp/request_owner.go
+++ b/stephttp/request_owner.go
@@ -290,10 +290,10 @@ func (o *requestOwner) call(ctx context.Context) APIResult {
 	duration := time.Since(o.startTime)
 
 	result := APIResult{
-		StatusCode: o.w.statusCode,
-		Headers:    flattenHeaders(o.w.Header()),
-		Body:       o.w.body.String(),
-		Duration:   duration,
+		Status:   o.w.statusCode,
+		Headers:  flattenHeaders(o.w.Header()),
+		Body:     o.w.body.String(),
+		Duration: duration,
 	}
 
 	if panicErr != nil {

--- a/stephttp/request_owner.go
+++ b/stephttp/request_owner.go
@@ -292,7 +292,7 @@ func (o *requestOwner) call(ctx context.Context) APIResult {
 	result := APIResult{
 		StatusCode: o.w.statusCode,
 		Headers:    flattenHeaders(o.w.Header()),
-		Body:       o.w.body.Bytes(),
+		Body:       o.w.body.String(),
 		Duration:   duration,
 	}
 
@@ -423,8 +423,7 @@ func (o *requestOwner) appendResult(ctx context.Context, res APIResult) error {
 	)
 
 	if o.config == nil || !o.config.OmitResponseBody {
-		// Append the fn complete opcode.
-		responseBody, err = json.Marshal(map[string]any{"data": res})
+		responseBody, err = json.Marshal(res)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- In https://github.com/inngest/inngest/pull/4119, we changed synchronous durable endpoint reporting to match the JS SDK, and in the process broke the Go SDK
- In this PR, we change the Go SDK to conform to the same format as the JS SDK
- Additionally, I've tested this locally to work with the new schema with the dev-cli, and also in prod

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR fixes the Go SDK's sync durable endpoint reporting to match the JS SDK wire format. Changes: rename `StatusCode`→`Status` (JSON: `status_code`→`status`), change `Body` from `[]byte` to `string`, and remove the `{"data": ...}` wrapper in `appendResult` so `APIResult` is marshaled directly.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a130e25fadf099363bfd03013f48ec598d810088.</sup>
<!-- /MENDRAL_SUMMARY -->