### PR TITLE
fix(connect): stale Connect websocket writes

### DIFF
--- a/.changeset/fix-connect-stale-websocket-writes.md
+++ b/.changeset/fix-connect-stale-websocket-writes.md
@@ -1,0 +1,5 @@
+---
+"inngestgo": patch
+---
+
+Fix Connect worker reply ACK handling and avoid writing request ACKs, replies, and lease extensions to retired websocket connections.

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -429,7 +429,7 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 
 func (h *connectHandler) handleMessageReplyAck(msg *connectproto.ConnectMessage) error {
 	var payload connectproto.WorkerReplyAckData
-	if err := proto.Unmarshal(msg.Payload, msg); err != nil {
+	if err := proto.Unmarshal(msg.Payload, &payload); err != nil {
 		return fmt.Errorf("could not unmarshal reply ack data: %w", err)
 	}
 

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"sync/atomic"
 	"time"
 )
 
@@ -111,6 +112,8 @@ type connection struct {
 
 	heartbeatInterval   time.Duration
 	extendLeaseInterval time.Duration
+
+	retired atomic.Bool
 }
 
 func (c *connection) logAttrs() []any {
@@ -119,6 +122,14 @@ func (c *connection) logAttrs() []any {
 		"gateway_group", c.gatewayGroupName,
 		"gateway_endpoint", c.gatewayEndpoint,
 	}
+}
+
+func (c *connection) retire() {
+	c.retired.Store(true)
+}
+
+func (c *connection) isRetired() bool {
+	return c.retired.Load()
 }
 
 func (h *connectHandler) prepareConnection(ctx context.Context, data connectionEstablishData, excludeGateways []string) (*connection, error) {
@@ -361,12 +372,14 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 			}
 
 			// Send a proper close frame
+			preparedConn.retire()
 			_ = preparedConn.ws.Close(websocket.StatusNormalClosure, connectproto.WorkerDisconnectReason_WORKER_SHUTDOWN.String())
 
 			return errGatewayDraining
 		}
 
 		l.Debug("read loop ended with error", "err", err)
+		preparedConn.retire()
 
 		// In case the gateway intentionally closed the connection, we'll receive a close error
 		cerr := websocket.CloseError{}
@@ -412,6 +425,7 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 	h.workerPool.Wait()
 
 	// Attempt to shut down connection if not already done
+	preparedConn.retire()
 	_ = preparedConn.ws.Close(websocket.StatusNormalClosure, connectproto.WorkerDisconnectReason_WORKER_SHUTDOWN.String())
 
 	// Attempt to flush leftover messages before closing

--- a/connect/handler_test.go
+++ b/connect/handler_test.go
@@ -554,18 +554,19 @@ func TestHandleInvokeMessageBuffersReplyWhenConnectionClosesAfterAck(t *testing.
 
 	serverSawAck := make(chan struct{})
 	serverClosed := make(chan struct{})
+	invokerRelease := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		conn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
 			InsecureSkipVerify: true,
 		})
 		r.NoError(err)
-		defer close(serverClosed)
 
 		var msg connectproto.ConnectMessage
 		err = wsReadProto(req.Context(), conn, &msg)
 		r.NoError(err)
 		r.Equal(connectproto.GatewayMessageType_WORKER_REQUEST_ACK, msg.Kind)
 		close(serverSawAck)
+		close(serverClosed)
 
 		_ = conn.Close(websocket.StatusInternalError, "connect_internal_error")
 	}))
@@ -581,7 +582,7 @@ func TestHandleInvokeMessageBuffersReplyWhenConnectionClosesAfterAck(t *testing.
 
 	apiClient := newWorkerApiClient("", nil)
 	invoker := &blockingTestInvoker{
-		release: serverClosed,
+		release: invokerRelease,
 	}
 	h := &connectHandler{
 		opts: Opts{
@@ -616,6 +617,12 @@ func TestHandleInvokeMessageBuffersReplyWhenConnectionClosesAfterAck(t *testing.
 		extendLeaseInterval: time.Hour,
 	}
 
+	go func() {
+		<-serverClosed
+		preparedConn.retire()
+		close(invokerRelease)
+	}()
+
 	err = h.handleInvokeMessage(ctx, preparedConn, msg)
 	r.NoError(err)
 	r.True(invoker.called.Load())
@@ -630,6 +637,47 @@ func TestHandleInvokeMessageBuffersReplyWhenConnectionClosesAfterAck(t *testing.
 	default:
 		t.Fatal("server did not receive worker request ack")
 	}
+}
+
+func TestHandleInvokeMessageSkipsQueuedRequestForRetiredConnection(t *testing.T) {
+	r := require.New(t)
+
+	apiClient := newWorkerApiClient("", nil)
+	invoker := &blockingTestInvoker{
+		release: make(chan struct{}),
+	}
+	h := &connectHandler{
+		invokers: map[string]FunctionInvoker{
+			"test-app": invoker,
+		},
+		logger:        slog.Default(),
+		messageBuffer: newMessageBuffer(apiClient, slog.Default()),
+	}
+
+	msg := mustExecutorRequestMessage(t, &connectproto.GatewayExecutorRequestData{
+		RequestId:      "request-id",
+		EnvId:          "env-id",
+		AppId:          "app-id",
+		AppName:        "test-app",
+		FunctionSlug:   "test-fn",
+		RequestPayload: mustJSON(t, sdkrequest.Request{}),
+		LeaseId:        "lease-id",
+	})
+
+	preparedConn := &connection{
+		connectionId:        "old-connection",
+		extendLeaseInterval: time.Hour,
+	}
+	preparedConn.retire()
+
+	err := h.handleInvokeMessage(context.Background(), preparedConn, msg)
+	r.NoError(err)
+	r.False(invoker.called.Load())
+
+	h.messageBuffer.lock.Lock()
+	defer h.messageBuffer.lock.Unlock()
+	r.Empty(h.messageBuffer.buffered)
+	r.Empty(h.messageBuffer.pendingAck)
 }
 
 type blockingTestInvoker struct {

--- a/connect/handler_test.go
+++ b/connect/handler_test.go
@@ -2,16 +2,20 @@ package connect
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/inngest/inngestgo/internal/sdkrequest"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -516,4 +520,157 @@ func TestHandleWorkerRequestExtendLeaseAck(t *testing.T) {
 			r.Equal(tt.expectedLeases, h.workerPool.inProgressLeases)
 		})
 	}
+}
+
+func TestHandleMessageReplyAckClearsPendingAck(t *testing.T) {
+	r := require.New(t)
+
+	apiClient := newWorkerApiClient("", nil)
+	h := &connectHandler{
+		messageBuffer: newMessageBuffer(apiClient, slog.Default()),
+	}
+	h.messageBuffer.pendingAck["request-id"] = &connectproto.SDKResponse{
+		RequestId: "request-id",
+	}
+
+	payload, err := proto.Marshal(&connectproto.WorkerReplyAckData{
+		RequestId: "request-id",
+	})
+	r.NoError(err)
+
+	err = h.handleMessageReplyAck(&connectproto.ConnectMessage{
+		Kind:    connectproto.GatewayMessageType_WORKER_REPLY_ACK,
+		Payload: payload,
+	})
+	r.NoError(err)
+
+	h.messageBuffer.lock.Lock()
+	defer h.messageBuffer.lock.Unlock()
+	r.NotContains(h.messageBuffer.pendingAck, "request-id")
+}
+
+func TestHandleInvokeMessageBuffersReplyWhenConnectionClosesAfterAck(t *testing.T) {
+	r := require.New(t)
+
+	serverSawAck := make(chan struct{})
+	serverClosed := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		r.NoError(err)
+		defer close(serverClosed)
+
+		var msg connectproto.ConnectMessage
+		err = wsReadProto(req.Context(), conn, &msg)
+		r.NoError(err)
+		r.Equal(connectproto.GatewayMessageType_WORKER_REQUEST_ACK, msg.Kind)
+		close(serverSawAck)
+
+		_ = conn.Close(websocket.StatusInternalError, "connect_internal_error")
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.Dial(ctx, wsURL, nil)
+	r.NoError(err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	apiClient := newWorkerApiClient("", nil)
+	invoker := &blockingTestInvoker{
+		release: serverClosed,
+	}
+	h := &connectHandler{
+		opts: Opts{
+			SDKLanguage: "go",
+			SDKVersion:  "test",
+		},
+		invokers: map[string]FunctionInvoker{
+			"test-app": invoker,
+		},
+		logger:        slog.Default(),
+		messageBuffer: newMessageBuffer(apiClient, slog.Default()),
+		workerPool: &workerPool{
+			inProgressLeases:     map[string]string{},
+			inProgressLeasesLock: sync.Mutex{},
+		},
+	}
+
+	msg := mustExecutorRequestMessage(t, &connectproto.GatewayExecutorRequestData{
+		RequestId:      "request-id",
+		AccountId:      "account-id",
+		EnvId:          "env-id",
+		AppId:          "app-id",
+		AppName:        "test-app",
+		FunctionSlug:   "test-fn",
+		RequestPayload: mustJSON(t, sdkrequest.Request{}),
+		LeaseId:        "lease-id",
+	})
+
+	preparedConn := &connection{
+		ws:                  clientConn,
+		connectionId:        "old-connection",
+		extendLeaseInterval: time.Hour,
+	}
+
+	err = h.handleInvokeMessage(ctx, preparedConn, msg)
+	r.NoError(err)
+	r.True(invoker.called.Load())
+
+	h.messageBuffer.lock.Lock()
+	defer h.messageBuffer.lock.Unlock()
+	r.Contains(h.messageBuffer.buffered, "request-id")
+	r.NotContains(h.messageBuffer.pendingAck, "request-id")
+
+	select {
+	case <-serverSawAck:
+	default:
+		t.Fatal("server did not receive worker request ack")
+	}
+}
+
+type blockingTestInvoker struct {
+	release <-chan struct{}
+	called  atomic.Bool
+}
+
+func (b *blockingTestInvoker) InvokeFunction(ctx context.Context, slug string, stepId *string, request sdkrequest.Request) (any, []sdkrequest.GeneratorOpcode, error) {
+	b.called.Store(true)
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case <-b.release:
+		return map[string]string{"ok": "true"}, nil, nil
+	}
+}
+
+func mustExecutorRequestMessage(t *testing.T, data *connectproto.GatewayExecutorRequestData) *connectproto.ConnectMessage {
+	t.Helper()
+
+	payload, err := proto.Marshal(data)
+	require.NoError(t, err)
+
+	return &connectproto.ConnectMessage{
+		Kind:    connectproto.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST,
+		Payload: payload,
+	}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+
+	payload, err := json.Marshal(v)
+	require.NoError(t, err)
+	return payload
+}
+
+func wsReadProto(ctx context.Context, conn *websocket.Conn, msg proto.Message) error {
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		return err
+	}
+	return proto.Unmarshal(data, msg)
 }

--- a/connect/invoke.go
+++ b/connect/invoke.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/inngest/inngest/pkg/connect/wsproto"
 	"github.com/inngest/inngest/pkg/enums"
@@ -18,9 +19,15 @@ const (
 	ResponseAcknowlegeDeadline = time.Second * 5
 )
 
+var errConnectionRetired = errors.New("connection retired")
+
 func (h *connectHandler) handleInvokeMessage(ctx context.Context, preparedConn *connection, msg *connectproto.ConnectMessage) error {
 	resp, err := h.connectInvoke(ctx, preparedConn, msg)
 	if err != nil {
+		if errors.Is(err, errConnectionRetired) {
+			h.logger.Debug("skipping sdk request because connection is retired")
+			return nil
+		}
 		h.logger.Error("failed to handle sdk request", "err", err)
 		// TODO Should we drop the connection? Continue receiving messages?
 		return fmt.Errorf("could not handle sdk request: %w", err)
@@ -43,14 +50,19 @@ func (h *connectHandler) handleInvokeMessage(ctx context.Context, preparedConn *
 	// that the message was truly passed on to the executor _unless_ we receive the ack message.
 	h.messageBuffer.addPending(ctx, resp, ResponseAcknowlegeDeadline)
 
+	if preparedConn.isRetired() {
+		h.messageBuffer.append(resp)
+		h.logger.Debug("buffering sdk response because connection is retired", "request_id", resp.RequestId)
+		return nil
+	}
+
 	err = wsproto.Write(ctx, preparedConn.ws, responseMessage)
 	if err != nil {
-		h.logger.Error("failed to send sdk response", "err", err)
-
 		// We received an error, the message definitely was not sent: Buffer message to retry
 		h.messageBuffer.append(resp)
+		h.logger.Debug("buffering sdk response after websocket write failure", "err", err, "request_id", resp.RequestId)
 
-		return fmt.Errorf("could not send sdk response: %w", err)
+		return nil
 	}
 
 	return nil
@@ -104,6 +116,9 @@ func (h *connectHandler) connectInvoke(ctx context.Context, preparedConn *connec
 
 	// Ack message
 	// If we're shutting down (context is canceled) we will not ack, which is desired!
+	if preparedConn.isRetired() {
+		return nil, errConnectionRetired
+	}
 	if err := wsproto.Write(ctx, preparedConn.ws, &connectproto.ConnectMessage{
 		Kind:    connectproto.GatewayMessageType_WORKER_REQUEST_ACK,
 		Payload: ackPayload,
@@ -160,6 +175,10 @@ func (h *connectHandler) connectInvoke(ctx context.Context, preparedConn *connec
 			if !ok {
 				// If the lease is not found (e.g. due to being removed after a nack),
 				// stop extending it.
+				cancelExtendLeaseCtx()
+				return
+			}
+			if preparedConn.isRetired() {
 				cancelExtendLeaseCtx()
 				return
 			}

--- a/connect/invoke.go
+++ b/connect/invoke.go
@@ -19,13 +19,19 @@ const (
 	ResponseAcknowlegeDeadline = time.Second * 5
 )
 
+// errConnectionRetired is only returned before WORKER_REQUEST_ACK is sent.
+// At that point the SDK has not claimed ownership of the request, so skipping
+// invocation lets the gateway/executor retry or reroute it instead of risking
+// duplicate execution.
 var errConnectionRetired = errors.New("connection retired")
 
 func (h *connectHandler) handleInvokeMessage(ctx context.Context, preparedConn *connection, msg *connectproto.ConnectMessage) error {
 	resp, err := h.connectInvoke(ctx, preparedConn, msg)
 	if err != nil {
 		if errors.Is(err, errConnectionRetired) {
-			h.logger.Debug("skipping sdk request because connection is retired")
+			// This is a pre-ACK skip. Once ACK succeeds, connectInvoke invokes
+			// the function with context.Background() and must let it finish.
+			h.logger.Debug("skipping sdk request because connection retired before ack")
 			return nil
 		}
 		h.logger.Error("failed to handle sdk request", "err", err)
@@ -114,8 +120,8 @@ func (h *connectHandler) connectInvoke(ctx context.Context, preparedConn *connec
 		}
 	}
 
-	// Ack message
-	// If we're shutting down (context is canceled) we will not ack, which is desired!
+	// ACK is the ownership boundary. If this generation is already retired,
+	// do not ACK and do not invoke; the gateway/executor can retry elsewhere.
 	if preparedConn.isRetired() {
 		return nil, errConnectionRetired
 	}

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -1,0 +1,620 @@
+#+TITLE: Connect Lifecycle Controller
+#+AUTHOR: Darwin D. Wu
+#+DATE: 2026-05-08
+#+STATUS: Draft
+#+STARTUP: showall
+
+* Overview
+
+Introduce a small lifecycle controller for Connect websocket generations and
+request execution.
+
+This is not a full-blown FSM rewrite. The goal is to centralize state
+transitions and their side effects so connection behavior is easier to reason
+about, easier to test, and less dependent on scattered booleans, deferred
+closes, channel sends, and context cancellation.
+
+The immediate motivation is SYS-856: queued and in-flight worker-pool jobs held
+a concrete =*connection= after the websocket read loop exited. Once that old
+websocket was closed, those jobs could still attempt ACK, reply, or lease
+extension writes through the stale =preparedConn.ws=.
+
+* Goals
+
+- Make websocket generation state explicit.
+- Correlate lifecycle side effects with state transitions.
+- Make allowed writes clear for each state.
+- Preserve the current intent that an ACKed function execution is not canceled
+  midway unless that becomes an explicit product decision.
+- Make request behavior testable without relying on real websocket timing races.
+- Keep manager, websocket generation, and request execution lifecycles separate.
+- Keep the implementation small and local to Connect internals.
+
+* Non-Goals
+
+- Do not introduce a general-purpose FSM library.
+- Do not model every possible goroutine state.
+- Do not collapse manager state and websocket generation state into one state.
+- Do not change Connect protocol semantics with the gateway in this plan.
+- Do not cancel in-flight user function execution on reconnect by default.
+- Do not replace the worker pool in this plan.
+
+* Current State
+
+Connect currently has three overlapping lifecycles.
+
+** Manager lifecycle
+
+=connectHandler= exposes coarse worker connection state:
+
+- =CONNECTING=
+- =ACTIVE=
+- =PAUSED=
+- =RECONNECTING=
+- =CLOSING=
+- =CLOSED=
+
+These states are currently API/logging state. They do not validate transitions
+or own lifecycle side effects.
+
+The manager run loop in =connect/handler.go=:
+
+1. starts an initial connection,
+2. listens for =notifyConnectedChan= and =notifyConnectDoneChan=,
+3. moves to =ACTIVE= after a connection is established,
+4. moves to =RECONNECTING= after reconnectable failure,
+5. flushes buffered replies via API before reconnect,
+6. backs off and starts another =h.connect(...)=,
+7. moves to =CLOSING= and =CLOSED= when =Close= is called.
+
+** Websocket generation lifecycle
+
+Each =connection= represents one concrete websocket generation.
+
+Current effective states are implicit:
+
+- prepared by =prepareConnection=
+- active while =handleConnection= read loop runs
+- gateway-draining when =GATEWAY_CLOSING= is received
+- unexpectedly closed when the read loop exits with error
+- graceful-closing during worker shutdown
+- retired after the SYS-856 fix marks it as no longer writable
+- transport-closed after =Close= or =CloseNow=
+
+Important behavior:
+
+- =GATEWAY_CLOSING= starts a replacement connection before closing the old
+  websocket.
+- unexpected read-loop exit causes reconnect.
+- graceful shutdown sends =WORKER_PAUSE=, waits for worker-pool completion,
+  retires the websocket, closes it, and flushes buffered replies.
+- a deferred =CloseNow= remains as a fallback safeguard.
+
+** Request lifecycle
+
+Worker-pool jobs currently carry:
+
+#+BEGIN_SRC go
+type workerPoolMsg struct {
+    msg          *connectproto.ConnectMessage
+    preparedConn *connection
+}
+#+END_SRC
+
+This intentionally binds a request to the websocket generation that received
+it.
+
+Current request behavior after the SYS-856 fix:
+
+- queued request on a retired connection: skip before ACK and do not invoke;
+- request that ACKs successfully: invoke function with =context.Background()=;
+- connection retired before reply: buffer the reply for API flush;
+- connection retired while lease extension loop is active: stop extending.
+
+* Problem Statement
+
+The implementation has lifecycle facts spread across multiple places:
+
+- manager state is set in =connectHandler.setState=;
+- websocket close behavior is in =handleConnection= branches and deferred
+  cleanup;
+- reconnect behavior is driven by =connectReport= messages;
+- request behavior checks connection retirement from =invoke.go=;
+- lease extension owns its own loop and exit conditions;
+- pending response acknowledgement is managed by =messageBuffer=.
+
+This makes it hard to answer basic questions locally:
+
+- Is this websocket generation allowed to write?
+- Does this transition close the websocket, only retire it, or both?
+- Are queued jobs allowed to invoke?
+- Are in-flight jobs allowed to finish?
+- Does drain behave differently from unexpected close?
+- Which side effects are guaranteed when a read loop exits?
+
+The current model can be made reliable, but the rules need a single home.
+
+* Design Direction
+
+Add a small lifecycle controller around each websocket generation. It should be
+an internal helper with validated transitions and explicit side effects.
+
+Do not build one global FSM. Keep lifecycles separate:
+
+- manager lifecycle: user-visible worker connection state;
+- websocket generation lifecycle: protocol write permissions and transport
+  cleanup for one =connection=;
+- request lifecycle: queued, ACKed, in-flight, reply sent, reply buffered.
+
+* Websocket Generation States
+
+Recommended internal states:
+
+- =New=
+- =Handshaking=
+- =Active=
+- =Draining=
+- =Retired=
+- =Closed=
+
+** New
+
+The connection object exists but the websocket is not ready for protocol use.
+
+Allowed writes:
+
+- none.
+
+** Handshaking
+
+The SDK is performing gateway hello/connect/ready protocol.
+
+Allowed writes:
+
+- handshake messages only.
+
+** Active
+
+The read loop is running and the gateway may forward executor requests.
+
+Allowed writes:
+
+- =WORKER_HEARTBEAT=
+- =WORKER_REQUEST_ACK=
+- =WORKER_REPLY=
+- =WORKER_REQUEST_EXTEND_LEASE=
+- graceful =WORKER_PAUSE= if shutdown begins
+
+** Draining
+
+The gateway requested drain. The old websocket may remain open while a
+replacement connection is established.
+
+Expected behavior:
+
+- no new requests should arrive from gateway;
+- in-flight work that has already ACKed may still complete;
+- replies may be written if policy allows, or buffered if the connection moves
+  to =Retired= before reply;
+- once replacement connection is established or the drain wait times out, move
+  to =Retired= and close the old transport.
+
+** Retired
+
+The websocket generation must no longer be used for request protocol writes.
+
+Allowed writes:
+
+- none for ACK, reply, heartbeat, or lease extension.
+
+Request behavior:
+
+- queued pre-ACK jobs skip invocation;
+- post-ACK in-flight jobs may finish and buffer replies;
+- lease extension loops exit.
+
+** Closed
+
+The transport has been closed or best-effort closed.
+
+Behavior:
+
+- same no-write behavior as =Retired=;
+- repeated close attempts are idempotent.
+
+* Transition Side Effects
+
+State transition methods should be the only place lifecycle side effects happen.
+
+Recommended internal API shape:
+
+#+BEGIN_SRC go
+func (c *connection) transition(to connPhase, reason string, attrs ...any) error
+
+func (c *connection) markActive(reason string)
+func (c *connection) beginDrain(reason string)
+func (c *connection) retire(reason string)
+func (c *connection) closeNormal(reason string)
+func (c *connection) closeNow(reason string)
+func (c *connection) canWrite(kind connectproto.GatewayMessageType) bool
+#+END_SRC
+
+The public-ish helpers can call a single private =transition= method so tests
+can validate both state and side effects.
+
+** On =Active -> Draining=
+
+- record reason and log transition once;
+- signal that the read loop is expected to end;
+- optionally reject new queued work if any arrives after drain begins.
+
+** On =Active -> Retired= or =Draining -> Retired=
+
+- mark the generation as no longer writable;
+- close a =done= or =noWrites= channel for request and lease loops;
+- cause queued pre-ACK work to fail before invocation;
+- cause post-ACK replies to buffer rather than write;
+- stop heartbeat and lease extension loops.
+
+** On =Retired -> Closed=
+
+- close websocket transport using the requested policy;
+- keep the transition idempotent.
+
+** On =Active -> Closed=
+
+- perform =Retired= side effects first;
+- then close the transport.
+
+* Manager State
+
+Keep manager state separate from websocket generation state.
+
+The manager can be =ACTIVE= while an older generation is =DRAINING= or
+=RETIRED= during reconnect overlap. That overlap is intentional during gateway
+drain and should not be hidden by a single global state.
+
+Manager states should remain user-facing and coarse:
+
+- =CONNECTING=
+- =ACTIVE=
+- =RECONNECTING=
+- =CLOSING=
+- =CLOSED=
+
+Potential cleanup:
+
+- remove =PAUSED= if unused, or define exactly when it is entered;
+- validate manager transitions separately from websocket generation transitions.
+
+* Request State
+
+Make request expectations explicit even if implemented lightly.
+
+Recommended conceptual states:
+
+- =Queued=
+- =Acking=
+- =Acked=
+- =InFlight=
+- =ReplyBuffered=
+- =ReplySent=
+- =Done=
+
+Initial implementation does not need a full request object. It can be enough to
+centralize checks:
+
+- before ACK: require generation =Active=;
+- after ACK: invocation continues independent of generation state;
+- before reply write: require generation =Active= or allowed =Draining=;
+- otherwise buffer reply;
+- before lease extend: require generation =Active=.
+
+* Phased Implementation Plan
+
+Each phase should be self-reviewable. Prefer small PRs that preserve behavior
+unless the phase explicitly changes behavior.
+
+** Phase 0: Baseline and current behavior lock-in
+
+Purpose: capture current lifecycle expectations before moving code.
+
+*** Implementation checklist
+
+- [ ] Keep the SYS-856 regressions covering reply ACK cleanup and stale
+  websocket writes.
+- [ ] Add or confirm coverage for graceful shutdown behavior:
+  - [ ] manager enters =CLOSING=;
+  - [ ] current active generation sends =WORKER_PAUSE=;
+  - [ ] worker pool is waited on;
+  - [ ] generation is retired and closed;
+  - [ ] buffered messages are flushed.
+- [ ] Add or confirm coverage for reconnect behavior:
+  - [ ] reconnectable read-loop errors move manager to =RECONNECTING=;
+  - [ ] buffered replies flush before reconnect attempt;
+  - [ ] non-reconnectable close reasons stop the manager.
+- [ ] Document any behavior that is intentionally preserved even if awkward.
+
+*** Validation checklist
+
+- [ ] =go test ./connect -count=1=
+- [ ] Tests fail if queued pre-ACK work invokes on a retired generation.
+- [ ] Tests fail if post-ACK in-flight work is canceled by generation
+  retirement.
+
+*** Exit criteria
+
+- [ ] Existing behavior is covered well enough to refactor with confidence.
+- [ ] Any known gaps are written down as explicit follow-up checkboxes.
+
+** Phase 1: Name and centralize websocket generation state
+
+Purpose: give one websocket generation an explicit lifecycle without changing
+protocol behavior.
+
+*** Implementation checklist
+
+- [ ] Add internal =connPhase= values:
+  - [ ] =New=
+  - [ ] =Handshaking=
+  - [ ] =Active=
+  - [ ] =Draining=
+  - [ ] =Retired=
+  - [ ] =Closed=
+- [ ] Add a private transition helper:
+  - [ ] validates allowed transitions;
+  - [ ] records reason and structured attrs;
+  - [ ] logs transition once;
+  - [ ] is concurrency-safe.
+- [ ] Replace the bare retired atomic with lifecycle methods:
+  - [ ] =phase()=
+  - [ ] =markActive(reason string, attrs ...any)=
+  - [ ] =beginDrain(reason string, attrs ...any)=
+  - [ ] =retire(reason string, attrs ...any)=
+  - [ ] =closeNormal(reason string, attrs ...any)=
+  - [ ] =closeNow(reason string, attrs ...any)=
+- [ ] Keep =Retired= as the state that means no future protocol writes.
+- [ ] Route existing retire and close call sites through the lifecycle methods.
+- [ ] Preserve the current fallback =CloseNow= behavior, but make its state
+  effect explicit.
+
+*** Test checklist
+
+- [ ] =New -> Handshaking -> Active= succeeds.
+- [ ] =Active -> Retired= disables writes.
+- [ ] =Draining -> Retired= succeeds.
+- [ ] =Retired -> Closed= is idempotent.
+- [ ] =Active -> Closed= applies retire effects before close.
+- [ ] Invalid transitions are rejected or logged clearly.
+
+*** Validation checklist
+
+- [ ] =go test ./connect -count=1=
+- [ ] Existing SYS-856 regressions still pass.
+
+*** Exit criteria
+
+- [ ] Every websocket generation has an observable phase.
+- [ ] Retire and close side effects are routed through lifecycle methods.
+- [ ] No request behavior changes are intentionally introduced in this phase.
+
+** Phase 2: Centralize write permission checks
+
+Purpose: make write eligibility state-driven rather than scattered
+=isRetired= checks.
+
+*** Implementation checklist
+
+- [ ] Add write permission helpers:
+  - [ ] =canWriteHeartbeat()=
+  - [ ] =canWriteRequestAck()=
+  - [ ] =canWriteReply()=
+  - [ ] =canWriteExtendLease()=
+  - [ ] optional generic =canWrite(kind connectproto.GatewayMessageType)=
+- [ ] Define write policy by phase:
+  - [ ] =New=: no writes;
+  - [ ] =Handshaking=: handshake writes only;
+  - [ ] =Active=: heartbeat, ACK, reply, extend lease, pause;
+  - [ ] =Draining=: explicitly decide reply/heartbeat policy;
+  - [ ] =Retired=: no protocol writes;
+  - [ ] =Closed=: no protocol writes.
+- [ ] Replace direct =preparedConn.isRetired()= checks in request ACK, reply,
+  heartbeat, and lease extension paths.
+- [ ] Return explicit no-write outcomes instead of attempting stale websocket
+  writes.
+- [ ] Keep websocket write failures after invocation as buffer-and-return-nil.
+
+*** Test checklist
+
+- [ ] Request ACK is not attempted outside allowed phases.
+- [ ] Reply write is not attempted after =Retired=.
+- [ ] Heartbeat write is not attempted after =Retired=.
+- [ ] Lease extension write is not attempted after =Retired=.
+- [ ] Websocket write failure after invocation buffers reply and returns no
+  request failure.
+
+*** Validation checklist
+
+- [ ] =go test ./connect -count=1=
+- [ ] Logs clearly distinguish "not writable due to phase" from websocket
+  transport write failure.
+
+*** Exit criteria
+
+- [ ] All protocol writes consult lifecycle state first.
+- [ ] No ACK, reply, heartbeat, or lease extension writes occur after
+  =Retired=.
+
+** Phase 3: Model gateway drain explicitly
+
+Purpose: make =GATEWAY_CLOSING= distinct from unexpected close and graceful
+worker shutdown.
+
+*** Implementation checklist
+
+- [ ] Move =GATEWAY_CLOSING= handling through =beginDrain=.
+- [ ] Preserve replacement-connection-before-close behavior.
+- [ ] Keep the old generation open during drain only for explicitly allowed
+  operations.
+- [ ] Move old generation from =Draining= to =Retired= after:
+  - [ ] replacement connection is established; or
+  - [ ] replacement wait times out.
+- [ ] Close the old transport through lifecycle close helpers.
+- [ ] Decide and implement =Draining= write policy:
+  - [ ] replies allowed until =Retired=; or
+  - [ ] replies always buffer once drain begins.
+- [ ] Decide heartbeat behavior in =Draining=:
+  - [ ] stop immediately; or
+  - [ ] continue until =Retired=.
+
+*** Test checklist
+
+- [ ] =GATEWAY_CLOSING= moves old generation to =Draining=.
+- [ ] Replacement connection can become =Active= while old generation is still
+  =Draining=.
+- [ ] Old generation moves to =Retired= and =Closed= after replacement.
+- [ ] Old generation moves to =Retired= and =Closed= after replacement timeout.
+- [ ] Queued work after drain does not start if ACK cannot be sent.
+- [ ] In-flight ACKed work follows the chosen =Draining= reply policy.
+
+*** Validation checklist
+
+- [ ] =go test ./connect -count=1=
+- [ ] Drain tests do not depend on real websocket close races.
+
+*** Exit criteria
+
+- [ ] Gateway drain behavior is explicit and separately testable.
+- [ ] Manager can be =ACTIVE= while an old generation is =DRAINING= or
+  =RETIRED=.
+
+** Phase 4: Clarify manager transitions
+
+Purpose: keep user-visible worker connection state clear without mixing it with
+websocket generation state.
+
+*** Implementation checklist
+
+- [ ] Add manager transition validation around =setState=.
+- [ ] Keep manager states coarse:
+  - [ ] =CONNECTING=
+  - [ ] =ACTIVE=
+  - [ ] =RECONNECTING=
+  - [ ] =CLOSING=
+  - [ ] =CLOSED=
+- [ ] Decide what to do with =PAUSED=:
+  - [ ] define exactly when it is entered; or
+  - [ ] remove it if it remains unused.
+- [ ] Make invalid manager transitions visible in logs.
+- [ ] Ensure reconnect overlap does not require changing manager state away
+  from =ACTIVE= while old generation drains.
+
+*** Test checklist
+
+- [ ] Initial connection moves =CONNECTING -> ACTIVE=.
+- [ ] Reconnectable failure moves =ACTIVE -> RECONNECTING -> ACTIVE=.
+- [ ] Non-reconnectable failure moves to =CLOSED=.
+- [ ] =Close= moves =ACTIVE/RECONNECTING -> CLOSING -> CLOSED=.
+- [ ] Double =Close= is idempotent.
+- [ ] Invalid transitions are rejected or logged clearly.
+
+*** Validation checklist
+
+- [ ] =go test ./connect -count=1=
+- [ ] Existing public =State()= behavior remains compatible.
+
+*** Exit criteria
+
+- [ ] Manager state documents user-visible lifecycle only.
+- [ ] Websocket generation state owns write and transport lifecycle.
+
+** Phase 5: Tighten request lifecycle boundaries
+
+Purpose: make request expectations explicit without changing function
+cancellation semantics.
+
+*** Implementation checklist
+
+- [ ] Add small request helper functions or a request context wrapper if needed.
+- [ ] Encode request boundaries:
+  - [ ] before ACK: require generation phase that allows ACK;
+  - [ ] after ACK: invocation continues independent of generation phase;
+  - [ ] before reply write: require generation phase that allows reply;
+  - [ ] otherwise buffer reply;
+  - [ ] before lease extend: require generation phase that allows lease extend.
+- [ ] Keep =InvokeFunction(context.Background(), ...)= behavior unless a
+  separate decision changes cancellation semantics.
+- [ ] Ensure pending ACK cleanup remains independent of generation lifecycle.
+- [ ] Make request logs include connection ID and generation phase where useful.
+
+*** Test checklist
+
+- [ ] Queued request on =Retired= does not ACK and does not invoke.
+- [ ] ACKed in-flight request on =Retired= completes and buffers reply.
+- [ ] Reply ACK clears =pendingAck=.
+- [ ] Lease extension exits when generation becomes =Retired=.
+- [ ] Request tests assert behavior by phase, not by websocket race timing.
+
+*** Validation checklist
+
+- [ ] =go test ./connect -count=1=
+- [ ] No SYS-856-style stale websocket write logs are expected from request
+  paths after =Retired=.
+
+*** Exit criteria
+
+- [ ] Request behavior is explicit for each relevant generation phase.
+- [ ] In-flight ACKed function execution still completes across reconnect.
+
+** Phase 6: Cleanup and documentation
+
+Purpose: remove redundant lifecycle mechanisms and document the final contract.
+
+*** Implementation checklist
+
+- [ ] Remove obsolete direct retired checks after all writes use phase helpers.
+- [ ] Remove redundant close calls if lifecycle close helpers make them
+  unnecessary.
+- [ ] Keep fallback close safeguards where they are still useful.
+- [ ] Update code comments around gateway drain, unexpected close, and graceful
+  shutdown.
+- [ ] Update this plan with decisions made during implementation.
+
+*** Test checklist
+
+- [ ] Full Connect package tests pass.
+- [ ] Add regression tests for any bug found during phases 1-5.
+
+*** Validation checklist
+
+- [ ] =go test ./connect -count=1=
+- [ ] Optional: run broader package test if touched imports or shared helpers
+  expand beyond =connect=.
+
+*** Exit criteria
+
+- [ ] Lifecycle rules are discoverable from code and this plan.
+- [ ] State transitions own their side effects.
+- [ ] Tests cover each state boundary that affects writes, close behavior, or
+  request execution.
+
+* Open Questions
+
+- Should =Draining= allow =WORKER_REPLY= writes until the generation is retired,
+  or should replies always buffer once drain begins?
+- Should heartbeat stop immediately on =Draining= or only on =Retired=?
+- Should graceful shutdown mark the generation as a distinct =Closing= phase
+  before =Retired=?
+- Should ACK write failures be treated identically to retired pre-ACK requests?
+- Should buffered replies be flushed immediately on retire or only from the
+  manager reconnect/close paths?
+
+* Success Criteria
+
+- Every websocket generation has an explicit phase.
+- State transition helpers own lifecycle side effects.
+- Request behavior is documented and tested for each relevant phase.
+- No ACK, reply, heartbeat, or lease extension writes occur after =Retired=.
+- In-flight ACKed function execution still completes across reconnect.
+- Gateway drain behavior remains compatible with current reconnect overlap.
+- Tests no longer need real closed-socket races to prove lifecycle behavior.

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -146,6 +146,85 @@ Do not build one global FSM. Keep lifecycles separate:
   cleanup for one =connection=;
 - request lifecycle: queued, ACKed, in-flight, reply sent, reply buffered.
 
+* Lifecycle Diagrams
+
+** Manager lifecycle
+
+#+BEGIN_SRC mermaid
+stateDiagram-v2
+    [*] --> CONNECTING
+    CONNECTING --> ACTIVE: initial connection established
+    CONNECTING --> CLOSED: initial non-reconnectable failure
+
+    ACTIVE --> RECONNECTING: reconnectable generation failure
+    RECONNECTING --> ACTIVE: replacement generation established
+    RECONNECTING --> CLOSED: max attempts or non-reconnectable failure
+
+    ACTIVE --> CLOSING: Close()
+    RECONNECTING --> CLOSING: Close()
+    CONNECTING --> CLOSING: Close()
+    CLOSING --> CLOSED: run loop ended and buffers flushed
+#+END_SRC
+
+The manager state is user-visible worker state. It does not describe every
+websocket generation. During gateway drain, the manager may be =ACTIVE= while
+an old generation is =Draining= and a replacement generation is becoming
+=Active=.
+
+** Websocket generation lifecycle
+
+#+BEGIN_SRC mermaid
+stateDiagram-v2
+    [*] --> New
+    New --> Handshaking: websocket dialed
+    Handshaking --> Active: GATEWAY_CONNECTION_READY
+    Handshaking --> Closed: handshake failed
+
+    Active --> Draining: GATEWAY_CLOSING
+    Draining --> Retired: replacement connected or timeout
+
+    Active --> Closing: worker Close()
+    Closing --> Retired: worker pool drained
+
+    Active --> Retired: unexpected read-loop exit
+    Retired --> Closed: close transport
+    Active --> Closed: close helper applies retire first
+    Closed --> Closed: idempotent close
+#+END_SRC
+
+State intent:
+
+- =Draining= is gateway-initiated replacement. It stops heartbeat, rejects new
+  ACKs, but may attempt already-ACKed replies and buffer on write failure.
+- =Closing= is worker-initiated graceful shutdown. It sends =WORKER_PAUSE=,
+  rejects new ACKs, waits for ACKed in-flight work, and then retires.
+- =Retired= is the hard no-write boundary. It emits a best-effort manager flush
+  notification but does not perform API I/O directly.
+
+** Request lifecycle
+
+#+BEGIN_SRC mermaid
+stateDiagram-v2
+    [*] --> Queued
+    Queued --> Skipped: generation cannot ACK
+    Queued --> Acking: generation allows ACK
+    Acking --> Skipped: ACK write failed
+    Acking --> InFlight: ACK write succeeded
+
+    InFlight --> ReplyBuffered: generation retired before reply
+    InFlight --> ReplySent: reply write succeeded
+    InFlight --> ReplyBuffered: reply write failed
+
+    ReplySent --> Done: WORKER_REPLY_ACK received
+    ReplySent --> ReplyBuffered: ACK deadline elapsed
+    ReplyBuffered --> Done: API flush succeeded
+    Skipped --> Done
+#+END_SRC
+
+The request ownership rule is strict: invocation starts only after ACK write
+success. After ACK succeeds, function execution continues even if the websocket
+generation later drains, closes, or retires.
+
 * Websocket Generation States
 
 Recommended internal states:
@@ -154,6 +233,7 @@ Recommended internal states:
 - =Handshaking=
 - =Active=
 - =Draining=
+- =Closing=
 - =Retired=
 - =Closed=
 
@@ -188,16 +268,34 @@ Allowed writes:
 ** Draining
 
 The gateway requested drain. The old websocket may remain open while a
-replacement connection is established.
+replacement connection is established. This is gateway-initiated replacement,
+not local worker shutdown.
 
 Expected behavior:
 
 - no new requests should arrive from gateway;
 - in-flight work that has already ACKed may still complete;
-- replies may be written if policy allows, or buffered if the connection moves
-  to =Retired= before reply;
+- heartbeat writes stop immediately so the old generation no longer advertises
+  active liveness;
+- already-ACKed in-flight replies attempt =WORKER_REPLY= over the draining
+  websocket first and fall back to buffering if the write fails;
 - once replacement connection is established or the drain wait times out, move
   to =Retired= and close the old transport.
+
+** Closing
+
+The local worker is shutting down gracefully. This is worker-initiated, not
+gateway-initiated replacement.
+
+Expected behavior:
+
+- send =WORKER_PAUSE= to tell the gateway this worker should not receive more
+  requests;
+- stop new request ACKs;
+- allow already-ACKed in-flight work to finish;
+- attempt already-ACKed in-flight replies while the websocket remains usable,
+  buffering on write failure;
+- after the worker pool drains, move to =Retired= and close the transport.
 
 ** Retired
 
@@ -212,6 +310,10 @@ Request behavior:
 - queued pre-ACK jobs skip invocation;
 - post-ACK in-flight jobs may finish and buffer replies;
 - lease extension loops exit.
+
+Retiring a generation should not perform API flush directly. It should emit a
+best-effort non-blocking notification to the manager that buffered replies may
+need flushing. The manager owns serialized API flush using current auth state.
 
 ** Closed
 
@@ -233,6 +335,7 @@ func (c *connection) transition(to connPhase, reason string, attrs ...any) error
 
 func (c *connection) markActive(reason string)
 func (c *connection) beginDrain(reason string)
+func (c *connection) beginClose(reason string)
 func (c *connection) retire(reason string)
 func (c *connection) closeNormal(reason string)
 func (c *connection) closeNow(reason string)
@@ -246,15 +349,30 @@ can validate both state and side effects.
 
 - record reason and log transition once;
 - signal that the read loop is expected to end;
+- stop heartbeat writes;
+- keep the old generation as a temporary reply path for already-ACKed
+  in-flight work;
 - optionally reject new queued work if any arrives after drain begins.
 
-** On =Active -> Retired= or =Draining -> Retired=
+** On =Active -> Closing=
+
+- record reason and log transition once;
+- send =WORKER_PAUSE=;
+- stop new request ACKs;
+- allow already-ACKed in-flight work to finish;
+- keep the old generation as a temporary reply path for already-ACKed replies;
+- document in code comments that =Closing= is local worker shutdown, not
+  gateway-initiated replacement.
+
+** On =Active -> Retired=, =Draining -> Retired=, or =Closing -> Retired=
 
 - mark the generation as no longer writable;
 - close a =done= or =noWrites= channel for request and lease loops;
 - cause queued pre-ACK work to fail before invocation;
 - cause post-ACK replies to buffer rather than write;
 - stop heartbeat and lease extension loops.
+- notify the manager, without blocking, that buffered replies may need API
+  flushing.
 
 ** On =Retired -> Closed=
 
@@ -305,10 +423,19 @@ Initial implementation does not need a full request object. It can be enough to
 centralize checks:
 
 - before ACK: require generation =Active=;
+- ACK write must succeed before invocation starts;
 - after ACK: invocation continues independent of generation state;
-- before reply write: require generation =Active= or allowed =Draining=;
+- before reply write: require generation =Active=, =Draining=, or =Closing=;
 - otherwise buffer reply;
 - before lease extend: require generation =Active=.
+
+Operational distinction:
+
+- non-writable phases before ACK, such as =Draining=, =Closing=, =Retired=, or
+  =Closed=, are expected lifecycle skips and should be logged at debug level;
+- ACK write failure while the generation is =Active= is a transport/protocol
+  failure and should be logged more prominently;
+- both cases skip invocation.
 
 * Phased Implementation Plan
 
@@ -359,6 +486,7 @@ protocol behavior.
   - [ ] =Handshaking=
   - [ ] =Active=
   - [ ] =Draining=
+  - [ ] =Closing=
   - [ ] =Retired=
   - [ ] =Closed=
 - [ ] Add a private transition helper:
@@ -370,9 +498,12 @@ protocol behavior.
   - [ ] =phase()=
   - [ ] =markActive(reason string, attrs ...any)=
   - [ ] =beginDrain(reason string, attrs ...any)=
+  - [ ] =beginClose(reason string, attrs ...any)=
   - [ ] =retire(reason string, attrs ...any)=
   - [ ] =closeNormal(reason string, attrs ...any)=
   - [ ] =closeNow(reason string, attrs ...any)=
+- [ ] Add a non-blocking manager flush notification hook that =retire= can
+  call without performing API I/O directly.
 - [ ] Keep =Retired= as the state that means no future protocol writes.
 - [ ] Route existing retire and close call sites through the lifecycle methods.
 - [ ] Preserve the current fallback =CloseNow= behavior, but make its state
@@ -382,7 +513,10 @@ protocol behavior.
 
 - [ ] =New -> Handshaking -> Active= succeeds.
 - [ ] =Active -> Retired= disables writes.
+- [ ] =Active -> Retired= notifies the manager that buffered replies may need
+  flushing.
 - [ ] =Draining -> Retired= succeeds.
+- [ ] =Active -> Closing -> Retired= succeeds.
 - [ ] =Retired -> Closed= is idempotent.
 - [ ] =Active -> Closed= applies retire effects before close.
 - [ ] Invalid transitions are rejected or logged clearly.
@@ -415,7 +549,9 @@ Purpose: make write eligibility state-driven rather than scattered
   - [ ] =New=: no writes;
   - [ ] =Handshaking=: handshake writes only;
   - [ ] =Active=: heartbeat, ACK, reply, extend lease, pause;
-  - [ ] =Draining=: explicitly decide reply/heartbeat policy;
+  - [ ] =Draining=: already-ACKed replies only, attempted first and buffered
+    on failure; no heartbeat;
+  - [ ] =Closing=: pause and already-ACKed replies only;
   - [ ] =Retired=: no protocol writes;
   - [ ] =Closed=: no protocol writes.
 - [ ] Replace direct =preparedConn.isRetired()= checks in request ACK, reply,
@@ -427,6 +563,9 @@ Purpose: make write eligibility state-driven rather than scattered
 *** Test checklist
 
 - [ ] Request ACK is not attempted outside allowed phases.
+- [ ] ACK write failure does not invoke the function.
+- [ ] Non-writable pre-ACK phases and ACK transport failures produce distinct
+  log messages.
 - [ ] Reply write is not attempted after =Retired=.
 - [ ] Heartbeat write is not attempted after =Retired=.
 - [ ] Lease extension write is not attempted after =Retired=.
@@ -460,12 +599,14 @@ worker shutdown.
   - [ ] replacement connection is established; or
   - [ ] replacement wait times out.
 - [ ] Close the old transport through lifecycle close helpers.
-- [ ] Decide and implement =Draining= write policy:
-  - [ ] replies allowed until =Retired=; or
-  - [ ] replies always buffer once drain begins.
-- [ ] Decide heartbeat behavior in =Draining=:
-  - [ ] stop immediately; or
-  - [ ] continue until =Retired=.
+- [ ] Implement =Draining= reply policy:
+  - [ ] attempt =WORKER_REPLY= for already-ACKed in-flight work;
+  - [ ] buffer reply if the draining websocket write fails;
+  - [ ] buffer immediately once the generation reaches =Retired=.
+- [ ] Stop heartbeat writes immediately when the generation enters
+  =Draining=.
+- [ ] Add comments near drain handling clarifying that =Draining= is
+  gateway-initiated replacement, not local worker shutdown.
 
 *** Test checklist
 
@@ -488,6 +629,45 @@ worker shutdown.
 - [ ] Manager can be =ACTIVE= while an old generation is =DRAINING= or
   =RETIRED=.
 
+** Phase 3.5: Model graceful websocket closing explicitly
+
+Purpose: make worker-initiated graceful shutdown distinct from gateway drain.
+
+*** Implementation checklist
+
+- [ ] Add =Closing= as a first-class websocket generation state.
+- [ ] Move graceful shutdown behavior through =beginClose=.
+- [ ] Send =WORKER_PAUSE= when entering =Closing=.
+- [ ] Stop new request ACKs in =Closing=.
+- [ ] Allow already-ACKed in-flight work to finish in =Closing=.
+- [ ] Attempt =WORKER_REPLY= for already-ACKed in-flight work while
+  =Closing=.
+- [ ] Buffer reply if the closing websocket write fails.
+- [ ] Move from =Closing= to =Retired= after worker-pool completion.
+- [ ] Close the transport through lifecycle close helpers.
+- [ ] Add comments near graceful shutdown handling clarifying that =Closing= is
+  local worker shutdown, not gateway-initiated replacement.
+
+*** Test checklist
+
+- [ ] Graceful shutdown moves active generation to =Closing= before
+  =Retired=.
+- [ ] Entering =Closing= sends =WORKER_PAUSE=.
+- [ ] Queued pre-ACK work does not start in =Closing=.
+- [ ] ACKed in-flight work can finish in =Closing=.
+- [ ] ACKed in-flight reply attempts websocket first and buffers on failure.
+- [ ] Generation moves to =Retired= and =Closed= after worker-pool completion.
+
+*** Validation checklist
+
+- [ ] =go test ./connect -count=1=
+- [ ] Tests distinguish =Draining= and =Closing= behavior.
+
+*** Exit criteria
+
+- [ ] Gateway drain and graceful shutdown have separate phases and comments.
+- [ ] Shutdown side effects are correlated with entering =Closing=.
+
 ** Phase 4: Clarify manager transitions
 
 Purpose: keep user-visible worker connection state clear without mixing it with
@@ -508,6 +688,12 @@ websocket generation state.
 - [ ] Make invalid manager transitions visible in logs.
 - [ ] Ensure reconnect overlap does not require changing manager state away
   from =ACTIVE= while old generation drains.
+- [ ] Add a serialized manager-owned flush path for lifecycle flush
+  notifications:
+  - [ ] notification is non-blocking;
+  - [ ] repeated notifications are coalesced or serialized;
+  - [ ] flush uses current manager auth state;
+  - [ ] reconnect and close flushes remain safety points.
 
 *** Test checklist
 
@@ -516,6 +702,8 @@ websocket generation state.
 - [ ] Non-reconnectable failure moves to =CLOSED=.
 - [ ] =Close= moves =ACTIVE/RECONNECTING -> CLOSING -> CLOSED=.
 - [ ] Double =Close= is idempotent.
+- [ ] Manager flush notification triggers one serialized API flush.
+- [ ] Repeated flush notifications do not start concurrent flushes.
 - [ ] Invalid transitions are rejected or logged clearly.
 
 *** Validation checklist
@@ -538,6 +726,7 @@ cancellation semantics.
 - [ ] Add small request helper functions or a request context wrapper if needed.
 - [ ] Encode request boundaries:
   - [ ] before ACK: require generation phase that allows ACK;
+  - [ ] ACK write must succeed before invocation starts;
   - [ ] after ACK: invocation continues independent of generation phase;
   - [ ] before reply write: require generation phase that allows reply;
   - [ ] otherwise buffer reply;
@@ -550,6 +739,7 @@ cancellation semantics.
 *** Test checklist
 
 - [ ] Queued request on =Retired= does not ACK and does not invoke.
+- [ ] ACK write failure while =Active= does not invoke.
 - [ ] ACKed in-flight request on =Retired= completes and buffers reply.
 - [ ] Reply ACK clears =pendingAck=.
 - [ ] Lease extension exits when generation becomes =Retired=.
@@ -597,17 +787,6 @@ Purpose: remove redundant lifecycle mechanisms and document the final contract.
 - [ ] State transitions own their side effects.
 - [ ] Tests cover each state boundary that affects writes, close behavior, or
   request execution.
-
-* Open Questions
-
-- Should =Draining= allow =WORKER_REPLY= writes until the generation is retired,
-  or should replies always buffer once drain begins?
-- Should heartbeat stop immediately on =Draining= or only on =Retired=?
-- Should graceful shutdown mark the generation as a distinct =Closing= phase
-  before =Retired=?
-- Should ACK write failures be treated identically to retired pre-ACK requests?
-- Should buffered replies be flushed immediately on retire or only from the
-  manager reconnect/close paths?
 
 * Success Criteria
 

--- a/scripts/check-plan-status.sh
+++ b/scripts/check-plan-status.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+plans_dir="${repo_root}/docs/plans"
+
+if [[ -z "${NO_COLOR:-}" && ( -t 1 || -n "${FORCE_COLOR:-}" ) ]]; then
+    color_reset=$'\033[0m'
+    color_bold=$'\033[1m'
+    color_red=$'\033[31m'
+    color_green=$'\033[32m'
+    color_yellow=$'\033[33m'
+    color_blue=$'\033[34m'
+    color_magenta=$'\033[35m'
+    color_dim=$'\033[2m'
+else
+    color_reset=""
+    color_bold=""
+    color_red=""
+    color_green=""
+    color_yellow=""
+    color_blue=""
+    color_magenta=""
+    color_dim=""
+fi
+
+if [[ ! -d "${plans_dir}" ]]; then
+    printf "%splans directory not found:%s %s\n" "${color_red}" "${color_reset}" "${plans_dir}" >&2
+    exit 1
+fi
+
+colorize_status() {
+    local status="$1"
+    local padded="$2"
+
+    case "${status}" in
+    Draft) printf "%s%s%s" "${color_blue}" "${padded}" "${color_reset}" ;;
+    Active) printf "%s%s%s" "${color_yellow}" "${padded}" "${color_reset}" ;;
+    Paused) printf "%s%s%s" "${color_magenta}" "${padded}" "${color_reset}" ;;
+    Done) printf "%s%s%s" "${color_green}" "${padded}" "${color_reset}" ;;
+    Cancelled) printf "%s%s%s" "${color_dim}" "${padded}" "${color_reset}" ;;
+    *) printf "%s%s%s" "${color_red}" "${padded}" "${color_reset}" ;;
+    esac
+}
+
+colorize_progress() {
+    local complete="$1"
+    local total="$2"
+    local padded="$3"
+
+    if [[ "${total}" -eq 0 ]]; then
+        printf "%s%s%s" "${color_dim}" "${padded}" "${color_reset}"
+    elif [[ "${complete}" -eq "${total}" ]]; then
+        printf "%s%s%s" "${color_green}" "${padded}" "${color_reset}"
+    elif [[ "${complete}" -eq 0 ]]; then
+        printf "%s%s%s" "${color_dim}" "${padded}" "${color_reset}"
+    else
+        printf "%s%s%s" "${color_yellow}" "${padded}" "${color_reset}"
+    fi
+}
+
+read_org_metadata() {
+    local plan="$1"
+
+    awk '
+      BEGIN { title = ""; status = "" }
+      {
+        lower = tolower($0)
+        if (title == "" && lower ~ /^#\+title:[[:space:]]*/) {
+          sub(/^#\+[Tt][Ii][Tt][Ll][Ee]:[[:space:]]*/, "", $0)
+          title = $0
+        } else if (status == "" && lower ~ /^#\+status:[[:space:]]*/) {
+          sub(/^#\+[Ss][Tt][Aa][Tt][Uu][Ss]:[[:space:]]*/, "", $0)
+          status = $0
+        }
+      }
+      END { printf "%s\t%s\n", title, status }
+    ' "${plan}"
+}
+
+read_markdown_metadata() {
+    local plan="$1"
+
+    awk '
+      BEGIN {
+        title = ""
+        status = ""
+        line_nr = 0
+        in_front_matter = 0
+      }
+      {
+        line_nr++
+
+        if (line_nr == 1 && $0 == "---") {
+          in_front_matter = 1
+          next
+        }
+
+        if (in_front_matter) {
+          if ($0 == "---") {
+            in_front_matter = 0
+            next
+          }
+
+          if (status == "" && tolower($0) ~ /^status:[[:space:]]*/) {
+            value = $0
+            sub(/^[^:]+:[[:space:]]*/, "", value)
+            status = value
+          }
+
+          if (title == "" && tolower($0) ~ /^title:[[:space:]]*/) {
+            value = $0
+            sub(/^[^:]+:[[:space:]]*/, "", value)
+            title = value
+          }
+
+          next
+        }
+
+        if (title == "" && $0 ~ /^# /) {
+          title = $0
+          sub(/^#[[:space:]]+/, "", title)
+        }
+      }
+      END { printf "%s\t%s\n", title, status }
+    ' "${plan}"
+}
+
+read_checklist_counts() {
+    local plan="$1"
+
+    awk '
+      BEGIN { complete = 0; total = 0 }
+      /^([[:space:]]*[-+*]|[[:space:]]*[0-9]+\.)[[:space:]]+\[[Xx ]\]/ {
+        total++
+        if ($0 ~ /\[[Xx]\]/) {
+          complete++
+        }
+      }
+      END { printf "%d %d\n", complete, total }
+    ' "${plan}"
+}
+
+printf "%s%-4s  %-10s  %-9s  %s%s\n" "${color_bold}" "Plan" "Status" "Progress" "Title" "${color_reset}"
+printf "%s%-4s  %-10s  %-9s  %s%s\n" "${color_dim}" "----" "------" "--------" "------------------------------" "${color_reset}"
+
+failures=0
+found=0
+
+shopt -s nullglob
+plans=("${plans_dir}"/*.org "${plans_dir}"/*.md)
+shopt -u nullglob
+
+if [[ "${#plans[@]}" -gt 0 ]]; then
+    mapfile -t plans < <(printf '%s\n' "${plans[@]}" | sort -V)
+fi
+
+for plan in "${plans[@]}"; do
+    found=1
+
+    filename="$(basename "${plan}")"
+    plan_id="${filename%%-*}"
+    extension="${filename##*.}"
+
+    case "${extension}" in
+    org)
+        metadata="$(read_org_metadata "${plan}")"
+        ;;
+    md)
+        metadata="$(read_markdown_metadata "${plan}")"
+        ;;
+    *)
+        continue
+        ;;
+    esac
+
+    title="${metadata%%$'\t'*}"
+    status="${metadata#*$'\t'}"
+
+    counts="$(read_checklist_counts "${plan}")"
+    complete_count="${counts%% *}"
+    total_count="${counts##* }"
+
+    if [[ -z "${title}" ]]; then
+        title="(missing title)"
+        failures=$((failures + 1))
+    fi
+
+    if [[ -z "${status}" ]]; then
+        status="(missing)"
+        failures=$((failures + 1))
+    fi
+
+    status_field="$(printf "%-10s" "${status}")"
+    progress_field="$(printf "%-9s" "${complete_count}/${total_count}")"
+    progress_text="$(colorize_progress "${complete_count}" "${total_count}" "${progress_field}")"
+    status_text="$(colorize_status "${status}" "${status_field}")"
+
+    printf "%-4s  %s  %s  %s\n" "${plan_id}" "${status_text}" "${progress_text}" "${title}"
+
+    if [[ "${status}" != "Draft" && "${status}" != "Active" && "${status}" != "Paused" && "${status}" != "Done" && "${status}" != "Cancelled" ]]; then
+        printf "  %sinvalid status%s in %s: %s\n" "${color_red}" "${color_reset}" "${filename}" "${status}" >&2
+        failures=$((failures + 1))
+    fi
+
+    if [[ "${total_count}" -gt 0 ]]; then
+        if [[ "${complete_count}" -eq "${total_count}" && "${status}" != "Done" && "${status}" != "Cancelled" ]]; then
+            printf "  %sexpected Done or Cancelled%s in %s: all checklist items are done\n" "${color_red}" "${color_reset}" "${filename}" >&2
+            failures=$((failures + 1))
+        fi
+
+        if [[ "${complete_count}" -lt "${total_count}" && "${status}" != "Draft" && "${status}" != "Active" && "${status}" != "Paused" && "${status}" != "Cancelled" ]]; then
+            printf "  %sexpected Draft, Active, Paused, or Cancelled%s in %s: checklist still has open items\n" "${color_red}" "${color_reset}" "${filename}" >&2
+            failures=$((failures + 1))
+        fi
+    fi
+done
+
+if [[ "${found}" -eq 0 ]]; then
+    printf "%sno plan files found%s in %s\n" "${color_red}" "${color_reset}" "${plans_dir}" >&2
+    exit 1
+fi
+
+if [[ "${failures}" -gt 0 ]]; then
+    echo
+    printf "%splan status check failed%s with %s issue(s).\n" "${color_red}" "${color_reset}" "${failures}" >&2
+    exit 1
+fi
+
+echo
+printf "%splan status check passed.%s\n" "${color_green}" "${color_reset}"


### PR DESCRIPTION
## Summary

Fixes SYS-856 by making Connect request handling aware of the owning websocket lifecycle.

Changes:
- Add regressions for `WORKER_REPLY_ACK` cleanup and stale websocket request handling.
- Decode `WORKER_REPLY_ACK` payloads into `WorkerReplyAckData`, so `pendingAck` entries are actually cleared.
- Mark old Connect websocket connections as retired when their read loop exits or the connection is otherwise closing.
- Skip queued executor requests before invocation when their owning connection is already retired and ACK cannot be sent.
- Preserve in-flight function execution: once a request has ACKed and invocation is underway, the function still completes, but the reply is buffered instead of writing to the retired websocket.
- Stop lease-extension writes once the owning connection is retired.

## Root Cause

Worker-pool jobs captured a concrete `*connection` and could continue after the read loop for that connection exited. The deferred close path then closed connection N while queued or in-flight jobs still attempted ACK, reply, or lease-extension writes through `preparedConn.ws`, producing `use of closed network connection` errors.

The reply ACK handler also unmarshaled into the outer `ConnectMessage` instead of `WorkerReplyAckData`, leaving `pendingAck` entries uncleared and amplifying fallback buffering.

## Validation

```sh
go test ./connect -count=1
```

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes SYS-856 by adding an `atomic.Bool` retired flag to `connection` that gates ACK, reply, and lease-extension writes. The pre-ACK retirement check in `connectInvoke` lets the gateway retry un-ACKed requests; post-ACK, invocation completes but replies are buffered instead of written to the stale websocket. Also corrects a proto unmarshaling bug in `handleMessageReplyAck` that was targeting `msg` instead of `&payload`, leaving `pendingAck` entries permanently uncleared.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit daaf24a3ed444115046d323009b6776fba23ea62.</sup>
<!-- /MENDRAL_SUMMARY -->