### PR TITLE
fix(connect): retire generation on ACK failure

### DIFF
--- a/connect/connection.go
+++ b/connect/connection.go
@@ -124,8 +124,8 @@ func (c *connection) logAttrs() []any {
 	}
 }
 
-func (c *connection) retire() {
-	c.retired.Store(true)
+func (c *connection) retire() bool {
+	return c.retired.CompareAndSwap(false, true)
 }
 
 func (c *connection) isRetired() bool {

--- a/connect/handler.go
+++ b/connect/handler.go
@@ -166,6 +166,9 @@ type connectHandler struct {
 	gracefulCloseEg errgroup.Group
 	auth            authContext
 	closed          atomic.Bool
+
+	startConnection  func(context.Context, connectionEstablishData, ...connectOpt)
+	reconnectBackoff func(int) time.Duration
 }
 
 // authContext is wrapper for information related to authentication
@@ -351,7 +354,11 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 				}
 
 				// continue to reconnect logic
-				delay := expBackoff(attempts)
+				reconnectBackoff := h.reconnectBackoff
+				if reconnectBackoff == nil {
+					reconnectBackoff = expBackoff
+				}
+				delay := reconnectBackoff(attempts)
 
 				l.Debug("reconnecting", "delay", delay.String(), "attempts", attempts)
 
@@ -389,7 +396,12 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 				connectCtx = startCtx
 			}
 
-			go h.connect(connectCtx, connectionEstablishData{
+			startConnection := h.startConnection
+			if startConnection == nil {
+				startConnection = h.connect
+			}
+
+			go startConnection(connectCtx, connectionEstablishData{
 				hashedSigningKey:      h.auth.hashedSigningKey,
 				numCpuCores:           int32(numCpuCores),
 				totalMem:              int64(totalMem),

--- a/connect/handler_test.go
+++ b/connect/handler_test.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -719,6 +720,7 @@ func TestHandleInvokeMessageBuffersReplyWhenConnectionClosesAfterAck(t *testing.
 
 func TestHandleInvokeMessageReturnsErrorWhenConnectionClosesBeforeAck(t *testing.T) {
 	r := require.New(t)
+	var logOutput bytes.Buffer
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		conn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
@@ -745,6 +747,7 @@ func TestHandleInvokeMessageReturnsErrorWhenConnectionClosesBeforeAck(t *testing
 	invoker := &blockingTestInvoker{
 		release: invokerRelease,
 	}
+	logger := slog.New(slog.NewTextHandler(&logOutput, nil))
 	h := &connectHandler{
 		opts: Opts{
 			SDKLanguage: "go",
@@ -753,8 +756,8 @@ func TestHandleInvokeMessageReturnsErrorWhenConnectionClosesBeforeAck(t *testing
 		invokers: map[string]FunctionInvoker{
 			"test-app": invoker,
 		},
-		logger:        slog.Default(),
-		messageBuffer: newMessageBuffer(apiClient, slog.Default()),
+		logger:        logger,
+		messageBuffer: newMessageBuffer(apiClient, logger),
 		workerPool: &workerPool{
 			inProgressLeases:     map[string]string{},
 			inProgressLeasesLock: sync.Mutex{},
@@ -783,8 +786,11 @@ func TestHandleInvokeMessageReturnsErrorWhenConnectionClosesBeforeAck(t *testing
 
 	err = h.handleInvokeMessage(ctx, preparedConn, msg)
 	r.Error(err)
+	r.ErrorIs(err, context.Canceled)
 	r.Contains(err.Error(), "could not write message to websocket")
 	r.NotContains(err.Error(), "PANIC")
+	r.Contains(logOutput.String(), "could not write message to websocket")
+	r.NotContains(logOutput.String(), "PANIC")
 	r.False(invoker.called.Load())
 }
 

--- a/connect/handler_test.go
+++ b/connect/handler_test.go
@@ -663,6 +663,7 @@ func TestHandleInvokeMessageBuffersReplyWhenConnectionClosesAfterAck(t *testing.
 	invoker := &blockingTestInvoker{
 		release: invokerRelease,
 	}
+	logger := slog.New(slog.DiscardHandler)
 	h := &connectHandler{
 		opts: Opts{
 			SDKLanguage: "go",
@@ -671,8 +672,8 @@ func TestHandleInvokeMessageBuffersReplyWhenConnectionClosesAfterAck(t *testing.
 		invokers: map[string]FunctionInvoker{
 			"test-app": invoker,
 		},
-		logger:        slog.Default(),
-		messageBuffer: newMessageBuffer(apiClient, slog.Default()),
+		logger:        logger,
+		messageBuffer: newMessageBuffer(apiClient, logger),
 		workerPool: &workerPool{
 			inProgressLeases:     map[string]string{},
 			inProgressLeasesLock: sync.Mutex{},
@@ -833,6 +834,100 @@ func TestHandleInvokeMessageSkipsQueuedRequestForRetiredConnection(t *testing.T)
 	defer h.messageBuffer.lock.Unlock()
 	r.Empty(h.messageBuffer.buffered)
 	r.Empty(h.messageBuffer.pendingAck)
+}
+
+func TestHandleInvokeMessageRetiresConnectionAfterAckWriteFailure(t *testing.T) {
+	r := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		r.NoError(err)
+
+		defer func() { _ = conn.CloseNow() }()
+		<-req.Context().Done()
+	}))
+	defer server.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelDial()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.Dial(dialCtx, wsURL, nil)
+	r.NoError(err)
+	_ = clientConn.CloseNow()
+
+	apiClient := newWorkerApiClient("", nil)
+	invokerRelease := make(chan struct{})
+	close(invokerRelease)
+	invoker := &blockingTestInvoker{
+		release: invokerRelease,
+	}
+	logger := slog.New(slog.DiscardHandler)
+	h := &connectHandler{
+		opts: Opts{
+			SDKLanguage: "go",
+			SDKVersion:  "test",
+		},
+		invokers: map[string]FunctionInvoker{
+			"test-app": invoker,
+		},
+		logger:        logger,
+		messageBuffer: newMessageBuffer(apiClient, logger),
+		workerPool: &workerPool{
+			inProgressLeases:     map[string]string{},
+			inProgressLeasesLock: sync.Mutex{},
+		},
+	}
+
+	preparedConn := &connection{
+		ws:                  clientConn,
+		connectionId:        "old-connection",
+		extendLeaseInterval: time.Hour,
+	}
+
+	firstMsg := mustExecutorRequestMessage(t, &connectproto.GatewayExecutorRequestData{
+		RequestId:      "request-id-1",
+		AccountId:      "account-id",
+		EnvId:          "env-id",
+		AppId:          "app-id",
+		AppName:        "test-app",
+		FunctionSlug:   "test-fn",
+		RequestPayload: mustJSON(t, sdkrequest.Request{}),
+		LeaseId:        "lease-id",
+	})
+
+	err = h.handleInvokeMessage(context.Background(), preparedConn, firstMsg)
+	r.Error(err)
+	r.Contains(err.Error(), "could not write message to websocket")
+	r.True(preparedConn.isRetired())
+	r.False(invoker.called.Load())
+
+	secondMsg := mustExecutorRequestMessage(t, &connectproto.GatewayExecutorRequestData{
+		RequestId:      "request-id-2",
+		AccountId:      "account-id",
+		EnvId:          "env-id",
+		AppId:          "app-id",
+		AppName:        "test-app",
+		FunctionSlug:   "test-fn",
+		RequestPayload: mustJSON(t, sdkrequest.Request{}),
+		LeaseId:        "lease-id",
+	})
+
+	err = h.handleInvokeMessage(context.Background(), preparedConn, secondMsg)
+	r.NoError(err)
+	r.False(invoker.called.Load())
+}
+
+func TestConnectionRetireIsIdempotent(t *testing.T) {
+	r := require.New(t)
+
+	conn := &connection{}
+
+	r.True(conn.retire())
+	r.False(conn.retire())
+	r.True(conn.isRetired())
 }
 
 type blockingTestInvoker struct {

--- a/connect/handler_test.go
+++ b/connect/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -188,6 +189,156 @@ func TestConnectReturnsTooManyConnectionsError(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for Connect to return")
 	}
+}
+
+func TestConnectReconnectableErrorEntersReconnectingAndFlushesBeforeNextAttempt(t *testing.T) {
+	r := require.New(t)
+
+	events := make(chan string, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal("/v0/connect/flush", req.URL.Path)
+
+		body, err := io.ReadAll(req.Body)
+		r.NoError(err)
+
+		var resp connectproto.SDKResponse
+		r.NoError(proto.Unmarshal(body, &resp))
+		r.Equal("request-id", resp.RequestId)
+
+		events <- "flush"
+
+		payload, err := proto.Marshal(&connectproto.FlushResponse{})
+		r.NoError(err)
+		w.Header().Set("Content-Type", "application/protobuf")
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	connectCtx, cancelConnect := context.WithCancel(context.Background())
+	defer cancelConnect()
+
+	logger := slog.New(slog.DiscardHandler)
+	apiClient := newWorkerApiClient(server.URL, nil)
+	var startCalls atomic.Int32
+	h := &connectHandler{
+		opts:                   Opts{IsDev: true},
+		logger:                 logger,
+		notifyConnectDoneChan:  make(chan connectReport),
+		notifyConnectedChan:    make(chan struct{}),
+		initiateConnectionChan: make(chan struct{}, 1),
+		apiClient:              apiClient,
+		messageBuffer:          newMessageBuffer(apiClient, logger),
+		state:                  ConnectionStateConnecting,
+		auth: authContext{
+			hashedSigningKey: []byte("signing-key"),
+		},
+		reconnectBackoff: func(int) time.Duration {
+			return 0
+		},
+	}
+	h.startConnection = func(context.Context, connectionEstablishData, ...connectOpt) {
+		call := startCalls.Add(1)
+		events <- fmt.Sprintf("start-%d", call)
+		if call == 1 {
+			h.notifyConnectedChan <- struct{}{}
+		}
+	}
+	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())
+	defer h.cancelWorkerCtx()
+
+	conn, err := h.Connect(connectCtx)
+	r.NoError(err)
+	r.Equal(h, conn)
+	r.Equal("start-1", <-events)
+
+	h.messageBuffer.append(&connectproto.SDKResponse{
+		RequestId: "request-id",
+	})
+	h.notifyConnectDoneChan <- connectReport{
+		reconnect: true,
+		err:       newReconnectErr(errors.New("read loop failed")),
+	}
+
+	deadline := time.After(time.Second)
+	for h.State() != ConnectionStateReconnecting {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for RECONNECTING state")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	r.Equal("flush", <-events)
+	r.Equal("start-2", <-events)
+
+	cancelConnect()
+	r.NoError(h.Close())
+}
+
+func TestConnectNonReconnectableCloseReasonStopsManager(t *testing.T) {
+	r := require.New(t)
+
+	connectCtx, cancelConnect := context.WithCancel(context.Background())
+	defer cancelConnect()
+
+	apiClient := newWorkerApiClient("", nil)
+	started := make(chan struct{}, 2)
+	h := &connectHandler{
+		opts:                   Opts{IsDev: true},
+		logger:                 slog.New(slog.DiscardHandler),
+		notifyConnectDoneChan:  make(chan connectReport),
+		notifyConnectedChan:    make(chan struct{}),
+		initiateConnectionChan: make(chan struct{}, 1),
+		apiClient:              apiClient,
+		messageBuffer:          newMessageBuffer(apiClient, slog.New(slog.DiscardHandler)),
+		state:                  ConnectionStateConnecting,
+		reconnectBackoff: func(int) time.Duration {
+			return 0
+		},
+	}
+	h.startConnection = func(context.Context, connectionEstablishData, ...connectOpt) {
+		started <- struct{}{}
+	}
+	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())
+	defer h.cancelWorkerCtx()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := h.Connect(connectCtx)
+		done <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial connection attempt")
+	}
+
+	h.notifyConnectDoneChan <- connectReport{
+		reconnect: true,
+		err: websocket.CloseError{
+			Code:   websocket.StatusPolicyViolation,
+			Reason: "not_retriable",
+		},
+	}
+
+	select {
+	case err := <-done:
+		r.Error(err)
+		r.Contains(err.Error(), `connect failed with error code "not_retriable"`)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Connect to return")
+	}
+
+	select {
+	case <-started:
+		t.Fatal("unexpected reconnect attempt for non-reconnectable close reason")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancelConnect()
+	r.NoError(h.gracefulCloseEg.Wait())
 }
 
 func TestCloseTransitionsThroughClosing(t *testing.T) {

--- a/connect/handler_test.go
+++ b/connect/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -187,6 +188,46 @@ func TestConnectReturnsTooManyConnectionsError(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for Connect to return")
 	}
+}
+
+func TestCloseTransitionsThroughClosing(t *testing.T) {
+	r := require.New(t)
+
+	releaseClose := make(chan struct{})
+	h := &connectHandler{
+		logger: slog.New(slog.DiscardHandler),
+		state:  ConnectionStateActive,
+	}
+	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())
+	h.gracefulCloseEg.Go(func() error {
+		<-releaseClose
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Close()
+	}()
+
+	deadline := time.After(time.Second)
+	for h.State() != ConnectionStateClosing {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for CLOSING state")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	close(releaseClose)
+
+	select {
+	case err := <-done:
+		r.NoError(err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Close")
+	}
+	r.Equal(ConnectionStateClosed, h.State())
 }
 
 func TestConnectInvokeUsesProtoRequestAndJobIDs(t *testing.T) {
@@ -716,6 +757,122 @@ func TestHandleInvokeMessageBuffersReplyWhenConnectionClosesAfterAck(t *testing.
 	case <-serverSawAck:
 	default:
 		t.Fatal("server did not receive worker request ack")
+	}
+}
+
+func TestHandleConnectionGracefulShutdownPausesDrainsAndFlushes(t *testing.T) {
+	r := require.New(t)
+
+	pauseSeen := make(chan struct{})
+	serverDone := make(chan struct{})
+	flushSeen := make(chan *connectproto.SDKResponse, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/ws":
+			conn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
+				InsecureSkipVerify: true,
+			})
+			r.NoError(err)
+
+			defer close(serverDone)
+			defer func() { _ = conn.CloseNow() }()
+
+			for {
+				var msg connectproto.ConnectMessage
+				err := wsReadProto(context.Background(), conn, &msg)
+				if err != nil {
+					return
+				}
+				if msg.Kind == connectproto.GatewayMessageType_WORKER_PAUSE {
+					close(pauseSeen)
+				}
+			}
+		case "/v0/connect/flush":
+			body, err := io.ReadAll(req.Body)
+			r.NoError(err)
+
+			var resp connectproto.SDKResponse
+			r.NoError(proto.Unmarshal(body, &resp))
+			flushSeen <- &resp
+
+			payload, err := proto.Marshal(&connectproto.FlushResponse{})
+			r.NoError(err)
+			w.Header().Set("Content-Type", "application/protobuf")
+			_, _ = w.Write(payload)
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+	clientConn, _, err := websocket.Dial(ctx, wsURL, nil)
+	r.NoError(err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	logger := slog.New(slog.DiscardHandler)
+	apiClient := newWorkerApiClient(server.URL, nil)
+	h := &connectHandler{
+		logger:        logger,
+		messageBuffer: newMessageBuffer(apiClient, logger),
+		workerPool: &workerPool{
+			inProgressLeases:     map[string]string{},
+			inProgressLeasesLock: sync.Mutex{},
+		},
+	}
+	h.workerPool.inProgress.Add(1)
+
+	preparedConn := &connection{
+		ws:                  clientConn,
+		connectionId:        "old-connection",
+		heartbeatInterval:   time.Hour,
+		extendLeaseInterval: time.Hour,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.handleConnection(ctx, connectionEstablishData{
+			hashedSigningKey: []byte("signing-key"),
+		}, preparedConn)
+	}()
+
+	cancel()
+
+	select {
+	case <-pauseSeen:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for worker pause")
+	}
+
+	h.messageBuffer.append(&connectproto.SDKResponse{
+		RequestId: "request-id",
+	})
+	h.workerPool.Done()
+
+	select {
+	case err := <-done:
+		r.NoError(err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for handleConnection")
+	}
+
+	r.True(preparedConn.isRetired())
+
+	select {
+	case resp := <-flushSeen:
+		r.Equal("request-id", resp.RequestId)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for buffered response flush")
+	}
+
+	select {
+	case <-serverDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for websocket close")
 	}
 }
 

--- a/connect/invoke.go
+++ b/connect/invoke.go
@@ -138,6 +138,7 @@ func (h *connectHandler) connectInvoke(ctx context.Context, preparedConn *connec
 		Kind:    connectproto.GatewayMessageType_WORKER_REQUEST_ACK,
 		Payload: ackPayload,
 	}); err != nil {
+		preparedConn.retire()
 		l.Error("error sending request ack", "error", err)
 		return nil, publicerr.Wrap(err, 400, "failed to ack worker request")
 	}

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -526,7 +526,7 @@ Purpose: capture current lifecycle expectations before moving code.
 
 *** Validation checklist
 
-- [ ] =go test ./connect -count=1=
+- [X] =go test ./connect -count=1=
 - [X] Tests fail if queued pre-ACK work invokes on a retired generation.
 - [X] Tests fail if post-ACK in-flight work is canceled by generation
   retirement.
@@ -536,7 +536,14 @@ Purpose: capture current lifecycle expectations before moving code.
 *** Exit criteria
 
 - [ ] Existing behavior is covered well enough to refactor with confidence.
-- [ ] Any known gaps are written down as explicit follow-up checkboxes.
+- [X] Any known gaps are written down as explicit follow-up checkboxes.
+
+*** Known follow-up gaps
+
+- [ ] Add manager reconnect loop coverage before Phase 1 centralizes state:
+  - [ ] reconnectable read-loop errors move manager to =RECONNECTING=;
+  - [ ] buffered replies flush before reconnect attempt;
+  - [ ] non-reconnectable websocket close reasons stop the manager.
 
 ** Phase 1: Name and centralize websocket generation state
 

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -501,12 +501,12 @@ Purpose: capture current lifecycle expectations before moving code.
   - [X] later queued pre-ACK work for that generation skips before ACK;
   - [X] only the first retire transition is observable; Phase 0 intentionally
     preserves existing close ownership outside request goroutines.
-- [ ] Add or confirm coverage for graceful shutdown behavior:
-  - [ ] manager enters =CLOSING=;
-  - [ ] current active generation sends =WORKER_PAUSE=;
-  - [ ] worker pool is waited on;
-  - [ ] generation is retired and closed;
-  - [ ] buffered messages are flushed.
+- [X] Add or confirm coverage for graceful shutdown behavior:
+  - [X] manager enters =CLOSING=;
+  - [X] current active generation sends =WORKER_PAUSE=;
+  - [X] worker pool is waited on;
+  - [X] generation is retired and closed;
+  - [X] buffered messages are flushed.
 - [ ] Add or confirm coverage for reconnect behavior:
   - [ ] reconnectable read-loop errors move manager to =RECONNECTING=;
   - [ ] buffered replies flush before reconnect attempt;

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -1,7 +1,7 @@
 #+TITLE: Connect Lifecycle Controller
 #+AUTHOR: Darwin D. Wu
 #+DATE: 2026-05-08
-#+STATUS: Draft
+#+STATUS: Active
 #+STARTUP: showall
 
 * Overview

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -496,10 +496,11 @@ Purpose: capture current lifecycle expectations before moving code.
   - [X] ACK write failure does not invoke the function;
   - [X] returned/logged error preserves the underlying websocket write error;
   - [X] returned/logged error does not render as =!PANIC=.
-- [ ] Add or confirm coverage for ACK write-failure fanout:
-  - [ ] first hard ACK write failure retires the generation;
-  - [ ] later queued pre-ACK work for that generation skips before ACK;
-  - [ ] only the first transition performs close side effects.
+- [X] Add or confirm coverage for ACK write-failure fanout:
+  - [X] first hard ACK write failure retires the generation;
+  - [X] later queued pre-ACK work for that generation skips before ACK;
+  - [X] only the first retire transition is observable; Phase 0 intentionally
+    preserves existing close ownership outside request goroutines.
 - [ ] Add or confirm coverage for graceful shutdown behavior:
   - [ ] manager enters =CLOSING=;
   - [ ] current active generation sends =WORKER_PAUSE=;
@@ -510,7 +511,18 @@ Purpose: capture current lifecycle expectations before moving code.
   - [ ] reconnectable read-loop errors move manager to =RECONNECTING=;
   - [ ] buffered replies flush before reconnect attempt;
   - [ ] non-reconnectable close reasons stop the manager.
-- [ ] Document any behavior that is intentionally preserved even if awkward.
+- [X] Document any behavior that is intentionally preserved even if awkward.
+
+*** Preserved behavior notes
+
+- ACK write failure retires the generation so later queued pre-ACK work skips,
+  but it does not close the websocket, flush buffered replies, or notify the
+  manager directly. Existing read-loop and manager shutdown paths still own
+  transport close and API flush side effects until the lifecycle controller is
+  introduced.
+- Reply write failure after invocation still buffers the response without
+  retiring the generation. Retiring on reply failure remains an explicit policy
+  decision for a later phase.
 
 *** Validation checklist
 

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -507,10 +507,10 @@ Purpose: capture current lifecycle expectations before moving code.
   - [X] worker pool is waited on;
   - [X] generation is retired and closed;
   - [X] buffered messages are flushed.
-- [ ] Add or confirm coverage for reconnect behavior:
-  - [ ] reconnectable read-loop errors move manager to =RECONNECTING=;
-  - [ ] buffered replies flush before reconnect attempt;
-  - [ ] non-reconnectable close reasons stop the manager.
+- [X] Add or confirm coverage for reconnect behavior:
+  - [X] reconnectable read-loop errors move manager to =RECONNECTING=;
+  - [X] buffered replies flush before reconnect attempt;
+  - [X] non-reconnectable close reasons stop the manager.
 - [X] Document any behavior that is intentionally preserved even if awkward.
 
 *** Preserved behavior notes
@@ -535,15 +535,12 @@ Purpose: capture current lifecycle expectations before moving code.
 
 *** Exit criteria
 
-- [ ] Existing behavior is covered well enough to refactor with confidence.
+- [X] Existing behavior is covered well enough to refactor with confidence.
 - [X] Any known gaps are written down as explicit follow-up checkboxes.
 
 *** Known follow-up gaps
 
-- [ ] Add manager reconnect loop coverage before Phase 1 centralizes state:
-  - [ ] reconnectable read-loop errors move manager to =RECONNECTING=;
-  - [ ] buffered replies flush before reconnect attempt;
-  - [ ] non-reconnectable websocket close reasons stop the manager.
+- None for Phase 0.
 
 ** Phase 1: Name and centralize websocket generation state
 

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -490,12 +490,12 @@ Purpose: capture current lifecycle expectations before moving code.
 
 *** Implementation checklist
 
-- [ ] Keep the SYS-856 regressions covering reply ACK cleanup and stale
+- [X] Keep the SYS-856 regressions covering reply ACK cleanup and stale
   websocket writes.
-- [ ] Keep the SYS-883 regression covering ACK write failure:
-  - [ ] ACK write failure does not invoke the function;
-  - [ ] returned/logged error preserves the underlying websocket write error;
-  - [ ] returned/logged error does not render as =!PANIC=.
+- [X] Keep the SYS-883 regression covering ACK write failure:
+  - [X] ACK write failure does not invoke the function;
+  - [X] returned/logged error preserves the underlying websocket write error;
+  - [X] returned/logged error does not render as =!PANIC=.
 - [ ] Add or confirm coverage for ACK write-failure fanout:
   - [ ] first hard ACK write failure retires the generation;
   - [ ] later queued pre-ACK work for that generation skips before ACK;
@@ -515,10 +515,10 @@ Purpose: capture current lifecycle expectations before moving code.
 *** Validation checklist
 
 - [ ] =go test ./connect -count=1=
-- [ ] Tests fail if queued pre-ACK work invokes on a retired generation.
-- [ ] Tests fail if post-ACK in-flight work is canceled by generation
+- [X] Tests fail if queued pre-ACK work invokes on a retired generation.
+- [X] Tests fail if post-ACK in-flight work is canceled by generation
   retirement.
-- [ ] Tests fail if ACK write failure logs hide the underlying transport error
+- [X] Tests fail if ACK write failure logs hide the underlying transport error
   behind panic-shaped formatting.
 
 *** Exit criteria


### PR DESCRIPTION
## Summary
- retire the websocket generation when `WORKER_REQUEST_ACK` fails so later queued pre-ACK work skips instead of writing to the same stale socket
- add Phase 0 lifecycle lock-in coverage for ACK failure logging, post-ACK reply buffering, graceful shutdown, and reconnect manager behavior
- update the connect lifecycle controller plan checklist and preserved-behavior notes for Phase 0

## Compatibility
- no public API changes
- ACKed function execution still continues independently of generation retirement
- reply write failures still buffer responses without retiring the generation
- request goroutines do not own websocket close or API flush side effects; existing read-loop and manager paths still own those

## Test plan
- `go test ./connect -count=1`