### PR TITLE
fix: mark event parse errors no-retry

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -1332,7 +1332,7 @@ func invoke(
 			for i, rawjson := range input.Events {
 				var evt event.Event
 				if err := json.Unmarshal(rawjson, &evt); err != nil {
-					mgr.SetErr(fmt.Errorf("error unmarshalling event for function: %w", err))
+					mgr.SetErr(sdkerrors.NoRetryError(fmt.Errorf("error unmarshalling event for function: %w", err)))
 					panic(sdkrequest.ControlHijack{})
 				}
 				evts[i] = &evt
@@ -1434,7 +1434,7 @@ func updateInput(
 			newEvent := reflect.New(eventType).Interface()
 
 			if err := json.Unmarshal(byt, newEvent); err != nil {
-				return fmt.Errorf("error unmarshalling event for function: %w", err)
+				return sdkerrors.NoRetryError(fmt.Errorf("error unmarshalling event for function: %w", err))
 			}
 			fnInput.FieldByName("Event").Set(reflect.ValueOf(newEvent).Elem())
 		}
@@ -1454,7 +1454,7 @@ func updateInput(
 				// The same type as the event.
 				newEvent := reflect.New(eventType).Interface()
 				if err := json.Unmarshal(byt, newEvent); err != nil {
-					return fmt.Errorf("error unmarshalling event for function: %w", err)
+					return sdkerrors.NoRetryError(fmt.Errorf("error unmarshalling event for function: %w", err))
 				}
 
 				newEvents = reflect.Append(newEvents, reflect.ValueOf(newEvent).Elem())
@@ -1471,7 +1471,7 @@ func updateInput(
 
 			newEvent := map[string]any{}
 			if err := json.Unmarshal(byt, &newEvent); err != nil {
-				return fmt.Errorf("error unmarshalling event for function: %w", err)
+				return sdkerrors.NoRetryError(fmt.Errorf("error unmarshalling event for function: %w", err))
 			}
 			fnInput.FieldByName("Event").Set(reflect.ValueOf(newEvent))
 		}
@@ -1487,7 +1487,7 @@ func updateInput(
 
 				var newEvent map[string]any
 				if err := json.Unmarshal(byt, &newEvent); err != nil {
-					return fmt.Errorf("error unmarshalling event for function: %w", err)
+					return sdkerrors.NoRetryError(fmt.Errorf("error unmarshalling event for function: %w", err))
 				}
 
 				newEvents[i] = newEvent

--- a/handler_test.go
+++ b/handler_test.go
@@ -467,6 +467,52 @@ func TestServe(t *testing.T) {
 		}()
 		require.Equal(t, 410, resp.StatusCode)
 	})
+
+	t.Run("It marks event payload parsing errors as no retry", func(t *testing.T) {
+		type TimeData struct {
+			Date time.Time `json:"date"`
+		}
+
+		c, err := NewClient(ClientOpts{AppID: "parse-errors"})
+		r.NoError(err)
+
+		var called int32
+		fn, err := CreateFunction(
+			c,
+			FunctionOpts{ID: "time-func"},
+			EventTrigger("test/time", nil),
+			func(ctx context.Context, input Input[TimeData]) (any, error) {
+				atomic.AddInt32(&called, 1)
+				return nil, nil
+			},
+		)
+		r.NoError(err)
+
+		server := httptest.NewServer(c.Serve())
+		defer server.Close()
+
+		queryParams := url.Values{}
+		queryParams.Add("fnId", fn.FullyQualifiedID())
+
+		event := GenericEvent[map[string]any]{
+			Name: "test/time",
+			Data: map[string]any{
+				"date": "2024-07-01",
+			},
+		}
+		resp := handlerPost(t, fmt.Sprintf("%s?%s", server.URL, queryParams.Encode()), createRequest(t, event))
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+
+		r.Equal(http.StatusInternalServerError, resp.StatusCode)
+		r.Equal("true", resp.Header.Get(HeaderKeyNoRetry))
+		r.Equal(int32(0), atomic.LoadInt32(&called))
+
+		body, err := io.ReadAll(resp.Body)
+		r.NoError(err)
+		r.Contains(string(body), "error unmarshalling event for function")
+	})
 }
 
 func TestSteps(t *testing.T) {


### PR DESCRIPTION
Fixes #16.

## Summary
- Mark event payload unmarshalling failures as no-retry errors.
- Preserve the existing error message while setting the executor-visible no-retry signal.
- Add regression coverage for malformed typed event payloads.

## Testing
- go test ./ -run 'TestServe/It_marks_event_payload_parsing_errors_as_no_retry' -count=1 -v
- go test ./...