### PR TITLE
fix(connect): model drain and closing lifecycles

### DIFF
--- a/connect/connection.go
+++ b/connect/connection.go
@@ -366,7 +366,7 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 			// a different gateway before retiring and closing the old transport
 			// so already-ACKed work has a bounded window to reply on the socket
 			// that still owns it.
-			notifyConnectedChan := make(chan struct{})
+			notifyConnectedChan := make(chan struct{}, 1)
 			go h.startConnectionFunc()(context.Background(), data, withNotifyConnectedChan(notifyConnectedChan), withExcludeGateways(preparedConn.gatewayGroupName))
 
 			select {

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -408,7 +408,10 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 		return newReconnectErr(fmt.Errorf("connection closed unexpectedly: %w", ctx.Err()))
 	}
 
-	// Perform graceful shutdown routine (parent context was cancelled)
+	// Graceful shutdown is local worker shutdown, not gateway-initiated
+	// replacement. Enter Closing to stop new request ACKs, notify the gateway
+	// with WORKER_PAUSE, and keep explicitly allowed writes for already-ACKed
+	// in-flight work until the worker pool drains.
 	if err := preparedConn.beginClose("worker context canceled"); err != nil {
 		l.Error("could not mark connection closing", "err", err)
 	}
@@ -433,6 +436,8 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 
 	// Wait until all in-progress requests are completed
 	h.workerPool.Wait()
+
+	preparedConn.retire("worker pool drained")
 
 	// Attempt to shut down connection if not already done
 	preparedConn.closeNormal(connectproto.WorkerDisconnectReason_WORKER_SHUTDOWN.String(), "reason", "worker shutdown")

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -19,6 +19,8 @@ import (
 
 var (
 	defaultWSReadLimit int64 = 10 * 1024 * 1024 // 10MB
+
+	gatewayDrainReplacementTimeout = 10 * time.Second
 )
 
 type connectReport struct {
@@ -209,8 +211,8 @@ func (h *connectHandler) prepareConnection(ctx context.Context, data connectionE
 }
 
 func (h *connectHandler) handleConnection(ctx context.Context, data connectionEstablishData, preparedConn *connection) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	backgroundCtx, stopBackground := context.WithCancel(ctx)
+	defer stopBackground()
 
 	l := h.logger.With(preparedConn.logAttrs()...)
 
@@ -233,7 +235,7 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 		defer heartbeatTicker.Stop()
 		for {
 			select {
-			case <-ctx.Done():
+			case <-backgroundCtx.Done():
 				return
 			case <-heartbeatTicker.C:
 				if !preparedConn.canWriteHeartbeat() {
@@ -259,7 +261,7 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 	go func() {
 		// Wait until initial heartbeat was sent out
 		select {
-		case <-ctx.Done():
+		case <-backgroundCtx.Done():
 			return
 		case <-time.After(preparedConn.heartbeatInterval):
 		}
@@ -269,7 +271,7 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 		defer heartbeatReplyTimer.Stop()
 		for {
 			select {
-			case <-ctx.Done():
+			case <-backgroundCtx.Done():
 				return
 			case <-heartbeatReceived:
 				if !heartbeatReplyTimer.Stop() {
@@ -308,12 +310,16 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 
 			switch msg.Kind {
 			case connectproto.GatewayMessageType_GATEWAY_CLOSING:
-				// Stop the read loop: We will not receive any further messages and should establish a new connection
-				// We can still use the old connection to send replies to the gateway
+				// Gateway drain is gateway-initiated replacement, not local
+				// worker shutdown. The old generation stops new request ACKs
+				// and heartbeats immediately, but remains open for explicitly
+				// allowed writes from already-ACKed in-flight work until a
+				// replacement connects or the replacement wait times out.
 				l.Info("gateway requested connection drain")
 				if err := preparedConn.beginDrain("gateway closing"); err != nil {
 					l.Error("could not mark connection draining", "err", err)
 				}
+				stopBackground()
 				return errGatewayDraining
 			case connectproto.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST:
 				// Handle invoke in a non-blocking way to allow for other messages to be processed
@@ -356,28 +362,20 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 	// - Worker shutdown, parent context got cancelled
 	if err := eg.Wait(); err != nil && ctx.Err() == nil {
 		if errors.Is(err, errGatewayDraining) {
-			// Gateway is draining and will not accept new connections.
-			// We must reconnect to a different gateway, only then can we close the old connection.
-			waitUntilConnected, doneWaiting := context.WithTimeout(context.Background(), 10*time.Second)
-			defer doneWaiting()
-
-			// Set up local notification listener
+			// Gateway is draining this generation. Establish a replacement on
+			// a different gateway before retiring and closing the old transport
+			// so already-ACKed work has a bounded window to reply on the socket
+			// that still owns it.
 			notifyConnectedChan := make(chan struct{})
-			go func() {
-				<-notifyConnectedChan
-				doneWaiting()
-			}()
+			go h.startConnectionFunc()(context.Background(), data, withNotifyConnectedChan(notifyConnectedChan), withExcludeGateways(preparedConn.gatewayGroupName))
 
-			// Establish new connection, notify the routine above when the new connection is established
-			go h.connect(context.Background(), data, withNotifyConnectedChan(notifyConnectedChan), withExcludeGateways(preparedConn.gatewayGroupName))
-
-			// Wait until the new connection is established before closing the old one
-			<-waitUntilConnected.Done()
-			if errors.Is(waitUntilConnected.Err(), context.DeadlineExceeded) {
+			select {
+			case <-notifyConnectedChan:
+			case <-time.After(gatewayDrainReplacementTimeout):
 				l.Error("timed out waiting for new connection to be established")
 			}
 
-			// Send a proper close frame
+			preparedConn.retire("gateway drain complete")
 			preparedConn.closeNormal(connectproto.WorkerDisconnectReason_WORKER_SHUTDOWN.String(), "reason", "gateway drain complete")
 
 			return errGatewayDraining
@@ -450,6 +448,13 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 	l.Debug("connection done")
 
 	return nil
+}
+
+func (h *connectHandler) startConnectionFunc() func(context.Context, connectionEstablishData, ...connectOpt) {
+	if h.startConnection != nil {
+		return h.startConnection
+	}
+	return h.connect
 }
 
 func (h *connectHandler) handleMessageReplyAck(msg *connectproto.ConnectMessage) error {

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -455,6 +455,9 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 	return nil
 }
 
+// startConnectionFunc returns the connection starter used by paths that need
+// to create a replacement generation. Production uses h.connect directly; tests
+// can set h.startConnection to control replacement timing without a real dial.
 func (h *connectHandler) startConnectionFunc() func(context.Context, connectionEstablishData, ...connectOpt) {
 	if h.startConnection != nil {
 		return h.startConnection

--- a/connect/connection_closing_test.go
+++ b/connect/connection_closing_test.go
@@ -58,6 +58,8 @@ func TestHandleConnectionGracefulShutdownEntersClosingBeforeRetireAndClose(t *te
 	}
 	h.workerPool.inProgress.Add(1)
 
+	// Keep one worker-pool item in progress so the test can observe Closing
+	// before worker-pool drain advances the generation to Retired and Closed.
 	preparedConn := &connection{
 		ws:                  clientConn,
 		connectionId:        "old-connection",
@@ -73,6 +75,9 @@ func TestHandleConnectionGracefulShutdownEntersClosingBeforeRetireAndClose(t *te
 
 	cancelHandle()
 
+	// The local shutdown path attempts WORKER_PAUSE while entering Closing.
+	// The log signal is deterministic even if the peer does not observe the
+	// frame before the read context unwinds.
 	waitForLogSignal(t, pauseLogSeen, "sending worker pause message")
 
 	r.Equal(connPhaseClosing, preparedConn.phase())
@@ -129,6 +134,8 @@ func TestHandleInvokeMessageSkipsAckDuringClosing(t *testing.T) {
 	r.NoError(preparedConn.markActive("test"))
 	r.NoError(preparedConn.beginClose("test"))
 
+	// Closing rejects new ownership claims, so queued pre-ACK work should skip
+	// without invoking the user function.
 	msg := mustExecutorRequestMessage(t, &connectproto.GatewayExecutorRequestData{
 		RequestId:      "request-id",
 		EnvId:          "env-id",
@@ -227,6 +234,8 @@ func TestHandleInvokeMessageAttemptsReplyDuringClosingForAckedWork(t *testing.T)
 		t.Fatal("server did not receive worker request ack")
 	}
 
+	// After ACK, the request remains owned during local shutdown. Closing
+	// should still allow the reply write while the worker pool drains.
 	r.NoError(preparedConn.beginClose("test"))
 	close(release)
 
@@ -324,6 +333,8 @@ func TestHandleInvokeMessageBuffersClosingReplyWriteFailure(t *testing.T) {
 		t.Fatal("server did not receive worker request ack")
 	}
 
+	// Closing allows the reply attempt; forcing the transport closed proves a
+	// failed closing write buffers the response without retiring here.
 	r.NoError(preparedConn.beginClose("test"))
 	_ = clientConn.CloseNow()
 	close(release)

--- a/connect/connection_closing_test.go
+++ b/connect/connection_closing_test.go
@@ -1,0 +1,343 @@
+package connect
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	connectproto "github.com/inngest/inngest/proto/gen/connect/v1"
+	"github.com/inngest/inngestgo/internal/sdkrequest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleConnectionGracefulShutdownEntersClosingBeforeRetireAndClose(t *testing.T) {
+	r := require.New(t)
+
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		r.NoError(err)
+		defer close(serverDone)
+		defer func() { _ = conn.CloseNow() }()
+
+		for {
+			var msg connectproto.ConnectMessage
+			if err := wsReadProto(context.Background(), conn, &msg); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	handleCtx, cancelHandle := context.WithCancel(context.Background())
+	defer cancelHandle()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	r.NoError(err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	pauseLogSeen := make(chan struct{})
+	logger := slog.New(newLogPatternHandler("sending worker pause message", pauseLogSeen))
+	h := &connectHandler{
+		logger:        logger,
+		messageBuffer: newMessageBuffer(newWorkerApiClient("", nil), logger),
+		workerPool: &workerPool{
+			inProgressLeases:     map[string]string{},
+			inProgressLeasesLock: sync.Mutex{},
+		},
+	}
+	h.workerPool.inProgress.Add(1)
+
+	preparedConn := &connection{
+		ws:                  clientConn,
+		connectionId:        "old-connection",
+		heartbeatInterval:   time.Hour,
+		extendLeaseInterval: time.Hour,
+	}
+	activateTestConnection(t, preparedConn)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.handleConnection(handleCtx, connectionEstablishData{}, preparedConn)
+	}()
+
+	cancelHandle()
+
+	waitForLogSignal(t, pauseLogSeen, "sending worker pause message")
+
+	r.Equal(connPhaseClosing, preparedConn.phase())
+
+	select {
+	case err := <-done:
+		t.Fatalf("handleConnection returned before worker pool drained: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	h.workerPool.Done()
+
+	select {
+	case err := <-done:
+		r.NoError(err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for handleConnection")
+	}
+
+	r.Equal(connPhaseClosed, preparedConn.phase())
+	r.True(preparedConn.isRetired())
+
+	select {
+	case <-serverDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for websocket close")
+	}
+}
+
+func TestHandleInvokeMessageSkipsAckDuringClosing(t *testing.T) {
+	r := require.New(t)
+	var logOutput bytes.Buffer
+
+	invoker := &blockingTestInvoker{
+		release: make(chan struct{}),
+	}
+	logger := slog.New(slog.NewTextHandler(&logOutput, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	h := &connectHandler{
+		opts: Opts{
+			SDKLanguage: "go",
+			SDKVersion:  "test",
+		},
+		invokers: map[string]FunctionInvoker{
+			"test-app": invoker,
+		},
+		logger:        logger,
+		messageBuffer: newMessageBuffer(newWorkerApiClient("", nil), logger),
+	}
+
+	preparedConn := newLifecycleTestConnection(nil)
+	r.NoError(preparedConn.transition(connPhaseHandshaking, "test"))
+	r.NoError(preparedConn.markActive("test"))
+	r.NoError(preparedConn.beginClose("test"))
+
+	msg := mustExecutorRequestMessage(t, &connectproto.GatewayExecutorRequestData{
+		RequestId:      "request-id",
+		EnvId:          "env-id",
+		AppId:          "app-id",
+		AppName:        "test-app",
+		FunctionSlug:   "test-fn",
+		RequestPayload: mustJSON(t, sdkrequest.Request{}),
+		LeaseId:        "lease-id",
+	})
+
+	err := h.handleInvokeMessage(context.Background(), preparedConn, msg)
+	r.NoError(err)
+	r.False(invoker.called.Load())
+	r.Contains(logOutput.String(), "phase does not allow request ack")
+	r.NotContains(logOutput.String(), "error sending request ack")
+}
+
+func TestHandleInvokeMessageAttemptsReplyDuringClosingForAckedWork(t *testing.T) {
+	r := require.New(t)
+
+	serverSawAck := make(chan struct{})
+	serverSawReply := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		r.NoError(err)
+		defer func() { _ = conn.CloseNow() }()
+
+		var ack connectproto.ConnectMessage
+		r.NoError(wsReadProto(req.Context(), conn, &ack))
+		r.Equal(connectproto.GatewayMessageType_WORKER_REQUEST_ACK, ack.Kind)
+		close(serverSawAck)
+
+		var reply connectproto.ConnectMessage
+		r.NoError(wsReadProto(req.Context(), conn, &reply))
+		r.Equal(connectproto.GatewayMessageType_WORKER_REPLY, reply.Kind)
+		close(serverSawReply)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.Dial(ctx, wsURL, nil)
+	r.NoError(err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	release := make(chan struct{})
+	invoker := &blockingTestInvoker{
+		release: release,
+	}
+	logger := slog.New(slog.DiscardHandler)
+	h := &connectHandler{
+		opts: Opts{
+			SDKLanguage: "go",
+			SDKVersion:  "test",
+		},
+		invokers: map[string]FunctionInvoker{
+			"test-app": invoker,
+		},
+		logger:        logger,
+		messageBuffer: newMessageBuffer(newWorkerApiClient("", nil), logger),
+		workerPool: &workerPool{
+			inProgressLeases:     map[string]string{},
+			inProgressLeasesLock: sync.Mutex{},
+		},
+	}
+
+	preparedConn := &connection{
+		ws:                  clientConn,
+		connectionId:        "old-connection",
+		extendLeaseInterval: time.Hour,
+	}
+	activateTestConnection(t, preparedConn)
+
+	msg := mustExecutorRequestMessage(t, &connectproto.GatewayExecutorRequestData{
+		RequestId:      "request-id",
+		EnvId:          "env-id",
+		AppId:          "app-id",
+		AppName:        "test-app",
+		FunctionSlug:   "test-fn",
+		RequestPayload: mustJSON(t, sdkrequest.Request{}),
+		LeaseId:        "lease-id",
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.handleInvokeMessage(ctx, preparedConn, msg)
+	}()
+
+	select {
+	case <-serverSawAck:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive worker request ack")
+	}
+
+	r.NoError(preparedConn.beginClose("test"))
+	close(release)
+
+	select {
+	case err := <-done:
+		r.NoError(err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for invoke")
+	}
+
+	select {
+	case <-serverSawReply:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive worker reply during close")
+	}
+
+	h.messageBuffer.lock.Lock()
+	defer h.messageBuffer.lock.Unlock()
+	r.NotContains(h.messageBuffer.buffered, "request-id")
+}
+
+func TestHandleInvokeMessageBuffersClosingReplyWriteFailure(t *testing.T) {
+	r := require.New(t)
+
+	serverSawAck := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		r.NoError(err)
+
+		var ack connectproto.ConnectMessage
+		r.NoError(wsReadProto(req.Context(), conn, &ack))
+		r.Equal(connectproto.GatewayMessageType_WORKER_REQUEST_ACK, ack.Kind)
+		close(serverSawAck)
+
+		_ = conn.Close(websocket.StatusInternalError, "connect_internal_error")
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.Dial(ctx, wsURL, nil)
+	r.NoError(err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	release := make(chan struct{})
+	invoker := &blockingTestInvoker{
+		release: release,
+	}
+	logger := slog.New(slog.DiscardHandler)
+	h := &connectHandler{
+		opts: Opts{
+			SDKLanguage: "go",
+			SDKVersion:  "test",
+		},
+		invokers: map[string]FunctionInvoker{
+			"test-app": invoker,
+		},
+		logger:        logger,
+		messageBuffer: newMessageBuffer(newWorkerApiClient("", nil), logger),
+		workerPool: &workerPool{
+			inProgressLeases:     map[string]string{},
+			inProgressLeasesLock: sync.Mutex{},
+		},
+	}
+
+	preparedConn := &connection{
+		ws:                  clientConn,
+		connectionId:        "old-connection",
+		extendLeaseInterval: time.Hour,
+	}
+	activateTestConnection(t, preparedConn)
+
+	msg := mustExecutorRequestMessage(t, &connectproto.GatewayExecutorRequestData{
+		RequestId:      "request-id",
+		EnvId:          "env-id",
+		AppId:          "app-id",
+		AppName:        "test-app",
+		FunctionSlug:   "test-fn",
+		RequestPayload: mustJSON(t, sdkrequest.Request{}),
+		LeaseId:        "lease-id",
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.handleInvokeMessage(ctx, preparedConn, msg)
+	}()
+
+	select {
+	case <-serverSawAck:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive worker request ack")
+	}
+
+	r.NoError(preparedConn.beginClose("test"))
+	_ = clientConn.CloseNow()
+	close(release)
+
+	select {
+	case err := <-done:
+		r.NoError(err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for invoke")
+	}
+
+	r.False(preparedConn.isRetired())
+
+	h.messageBuffer.lock.Lock()
+	defer h.messageBuffer.lock.Unlock()
+	r.Contains(h.messageBuffer.buffered, "request-id")
+}

--- a/connect/connection_drain_test.go
+++ b/connect/connection_drain_test.go
@@ -1,0 +1,406 @@
+package connect
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/inngest/inngest/pkg/connect/wsproto"
+	connectproto "github.com/inngest/inngest/proto/gen/connect/v1"
+	"github.com/inngest/inngestgo/internal/sdkrequest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleConnectionGatewayClosingDrainsUntilReplacementConnected(t *testing.T) {
+	r := require.New(t)
+
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		r.NoError(err)
+		defer close(serverDone)
+		defer func() { _ = conn.CloseNow() }()
+
+		r.NoError(wsproto.Write(context.Background(), conn, &connectproto.ConnectMessage{
+			Kind: connectproto.GatewayMessageType_GATEWAY_CLOSING,
+		}))
+
+		for {
+			var msg connectproto.ConnectMessage
+			if err := wsReadProto(req.Context(), conn, &msg); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.Dial(ctx, wsURL, nil)
+	r.NoError(err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	logger := slog.New(slog.DiscardHandler)
+	replacementStarted := make(chan []string, 1)
+	releaseReplacement := make(chan struct{})
+	h := &connectHandler{
+		logger:        logger,
+		messageBuffer: newMessageBuffer(newWorkerApiClient("", nil), logger),
+		workerPool: &workerPool{
+			inProgressLeases:     map[string]string{},
+			inProgressLeasesLock: sync.Mutex{},
+		},
+	}
+	h.startConnection = func(_ context.Context, _ connectionEstablishData, opts ...connectOpt) {
+		o := connectOpts{}
+		for _, opt := range opts {
+			opt(&o)
+		}
+
+		replacementStarted <- o.excludeGateways
+		<-releaseReplacement
+
+		if o.notifyConnectedChan != nil {
+			o.notifyConnectedChan <- struct{}{}
+			close(o.notifyConnectedChan)
+		}
+	}
+
+	preparedConn := &connection{
+		ws:                clientConn,
+		gatewayGroupName:  "old-gateway",
+		connectionId:      "old-connection",
+		heartbeatInterval: time.Hour,
+	}
+	activateTestConnection(t, preparedConn)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.handleConnection(ctx, connectionEstablishData{}, preparedConn)
+	}()
+
+	select {
+	case excluded := <-replacementStarted:
+		r.Equal([]string{"old-gateway"}, excluded)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for replacement connection attempt")
+	}
+
+	r.Equal(connPhaseDraining, preparedConn.phase())
+	r.False(preparedConn.canWriteHeartbeat())
+	r.False(preparedConn.canWriteRequestAck())
+	r.True(preparedConn.canWriteReply())
+
+	close(releaseReplacement)
+
+	select {
+	case err := <-done:
+		r.ErrorIs(err, errGatewayDraining)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for handleConnection")
+	}
+
+	r.Equal(connPhaseClosed, preparedConn.phase())
+	r.True(preparedConn.isRetired())
+
+	select {
+	case <-serverDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for old websocket close")
+	}
+}
+
+func TestHandleConnectionGatewayClosingRetiresAndClosesAfterReplacementTimeout(t *testing.T) {
+	r := require.New(t)
+
+	originalTimeout := gatewayDrainReplacementTimeout
+	gatewayDrainReplacementTimeout = 25 * time.Millisecond
+	t.Cleanup(func() {
+		gatewayDrainReplacementTimeout = originalTimeout
+	})
+
+	serverDone := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		r.NoError(err)
+		defer close(serverDone)
+		defer func() { _ = conn.CloseNow() }()
+
+		r.NoError(wsproto.Write(context.Background(), conn, &connectproto.ConnectMessage{
+			Kind: connectproto.GatewayMessageType_GATEWAY_CLOSING,
+		}))
+
+		for {
+			var msg connectproto.ConnectMessage
+			if err := wsReadProto(req.Context(), conn, &msg); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.Dial(ctx, wsURL, nil)
+	r.NoError(err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	logger := slog.New(slog.DiscardHandler)
+	replacementStarted := make(chan struct{})
+	h := &connectHandler{
+		logger:        logger,
+		messageBuffer: newMessageBuffer(newWorkerApiClient("", nil), logger),
+		workerPool: &workerPool{
+			inProgressLeases:     map[string]string{},
+			inProgressLeasesLock: sync.Mutex{},
+		},
+	}
+	h.startConnection = func(context.Context, connectionEstablishData, ...connectOpt) {
+		close(replacementStarted)
+	}
+
+	preparedConn := &connection{
+		ws:                clientConn,
+		gatewayGroupName:  "old-gateway",
+		connectionId:      "old-connection",
+		heartbeatInterval: time.Hour,
+	}
+	activateTestConnection(t, preparedConn)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.handleConnection(ctx, connectionEstablishData{}, preparedConn)
+	}()
+
+	select {
+	case <-replacementStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for replacement connection attempt")
+	}
+
+	select {
+	case err := <-done:
+		r.ErrorIs(err, errGatewayDraining)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for replacement timeout")
+	}
+
+	r.Equal(connPhaseClosed, preparedConn.phase())
+	r.True(preparedConn.isRetired())
+
+	select {
+	case <-serverDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for old websocket close")
+	}
+}
+
+func TestHandleInvokeMessageAttemptsReplyDuringDrainForAckedWork(t *testing.T) {
+	r := require.New(t)
+
+	serverSawAck := make(chan struct{})
+	serverSawReply := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		r.NoError(err)
+		defer func() { _ = conn.CloseNow() }()
+
+		var ack connectproto.ConnectMessage
+		r.NoError(wsReadProto(req.Context(), conn, &ack))
+		r.Equal(connectproto.GatewayMessageType_WORKER_REQUEST_ACK, ack.Kind)
+		close(serverSawAck)
+
+		var reply connectproto.ConnectMessage
+		r.NoError(wsReadProto(req.Context(), conn, &reply))
+		r.Equal(connectproto.GatewayMessageType_WORKER_REPLY, reply.Kind)
+		close(serverSawReply)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.Dial(ctx, wsURL, nil)
+	r.NoError(err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	release := make(chan struct{})
+	invoker := &blockingTestInvoker{
+		release: release,
+	}
+	logger := slog.New(slog.DiscardHandler)
+	h := &connectHandler{
+		opts: Opts{
+			SDKLanguage: "go",
+			SDKVersion:  "test",
+		},
+		invokers: map[string]FunctionInvoker{
+			"test-app": invoker,
+		},
+		logger:        logger,
+		messageBuffer: newMessageBuffer(newWorkerApiClient("", nil), logger),
+		workerPool: &workerPool{
+			inProgressLeases:     map[string]string{},
+			inProgressLeasesLock: sync.Mutex{},
+		},
+	}
+
+	preparedConn := &connection{
+		ws:                  clientConn,
+		connectionId:        "old-connection",
+		extendLeaseInterval: time.Hour,
+	}
+	activateTestConnection(t, preparedConn)
+
+	msg := mustExecutorRequestMessage(t, &connectproto.GatewayExecutorRequestData{
+		RequestId:      "request-id",
+		EnvId:          "env-id",
+		AppId:          "app-id",
+		AppName:        "test-app",
+		FunctionSlug:   "test-fn",
+		RequestPayload: mustJSON(t, sdkrequest.Request{}),
+		LeaseId:        "lease-id",
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.handleInvokeMessage(ctx, preparedConn, msg)
+	}()
+
+	select {
+	case <-serverSawAck:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive worker request ack")
+	}
+
+	r.NoError(preparedConn.beginDrain("test"))
+	close(release)
+
+	select {
+	case err := <-done:
+		r.NoError(err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for invoke")
+	}
+
+	select {
+	case <-serverSawReply:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive worker reply during drain")
+	}
+
+	h.messageBuffer.lock.Lock()
+	defer h.messageBuffer.lock.Unlock()
+	r.NotContains(h.messageBuffer.buffered, "request-id")
+}
+
+func TestHandleInvokeMessageBuffersDrainingReplyWriteFailure(t *testing.T) {
+	r := require.New(t)
+
+	serverSawAck := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		r.NoError(err)
+
+		var ack connectproto.ConnectMessage
+		r.NoError(wsReadProto(req.Context(), conn, &ack))
+		r.Equal(connectproto.GatewayMessageType_WORKER_REQUEST_ACK, ack.Kind)
+		close(serverSawAck)
+
+		_ = conn.Close(websocket.StatusInternalError, "connect_internal_error")
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.Dial(ctx, wsURL, nil)
+	r.NoError(err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	release := make(chan struct{})
+	invoker := &blockingTestInvoker{
+		release: release,
+	}
+	logger := slog.New(slog.DiscardHandler)
+	h := &connectHandler{
+		opts: Opts{
+			SDKLanguage: "go",
+			SDKVersion:  "test",
+		},
+		invokers: map[string]FunctionInvoker{
+			"test-app": invoker,
+		},
+		logger:        logger,
+		messageBuffer: newMessageBuffer(newWorkerApiClient("", nil), logger),
+		workerPool: &workerPool{
+			inProgressLeases:     map[string]string{},
+			inProgressLeasesLock: sync.Mutex{},
+		},
+	}
+
+	preparedConn := &connection{
+		ws:                  clientConn,
+		connectionId:        "old-connection",
+		extendLeaseInterval: time.Hour,
+	}
+	activateTestConnection(t, preparedConn)
+
+	msg := mustExecutorRequestMessage(t, &connectproto.GatewayExecutorRequestData{
+		RequestId:      "request-id",
+		EnvId:          "env-id",
+		AppId:          "app-id",
+		AppName:        "test-app",
+		FunctionSlug:   "test-fn",
+		RequestPayload: mustJSON(t, sdkrequest.Request{}),
+		LeaseId:        "lease-id",
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.handleInvokeMessage(ctx, preparedConn, msg)
+	}()
+
+	select {
+	case <-serverSawAck:
+	case <-time.After(time.Second):
+		t.Fatal("server did not receive worker request ack")
+	}
+
+	r.NoError(preparedConn.beginDrain("test"))
+	_ = clientConn.CloseNow()
+	close(release)
+
+	select {
+	case err := <-done:
+		r.NoError(err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for invoke")
+	}
+
+	r.False(preparedConn.isRetired())
+
+	h.messageBuffer.lock.Lock()
+	defer h.messageBuffer.lock.Unlock()
+	r.Contains(h.messageBuffer.buffered, "request-id")
+}

--- a/connect/connection_drain_test.go
+++ b/connect/connection_drain_test.go
@@ -209,6 +209,107 @@ func TestHandleConnectionGatewayClosingRetiresAndClosesAfterReplacementTimeout(t
 	}
 }
 
+func TestHandleConnectionGatewayClosingLateReplacementNotificationDoesNotBlock(t *testing.T) {
+	r := require.New(t)
+
+	originalTimeout := gatewayDrainReplacementTimeout
+	gatewayDrainReplacementTimeout = 25 * time.Millisecond
+	t.Cleanup(func() {
+		gatewayDrainReplacementTimeout = originalTimeout
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		conn, err := websocket.Accept(w, req, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		r.NoError(err)
+		defer func() { _ = conn.CloseNow() }()
+
+		r.NoError(wsproto.Write(context.Background(), conn, &connectproto.ConnectMessage{
+			Kind: connectproto.GatewayMessageType_GATEWAY_CLOSING,
+		}))
+
+		for {
+			var msg connectproto.ConnectMessage
+			if err := wsReadProto(req.Context(), conn, &msg); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, _, err := websocket.Dial(ctx, wsURL, nil)
+	r.NoError(err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	logger := slog.New(slog.DiscardHandler)
+	replacementStarted := make(chan struct{})
+	releaseReplacement := make(chan struct{})
+	replacementFinished := make(chan struct{})
+	h := &connectHandler{
+		logger:        logger,
+		messageBuffer: newMessageBuffer(newWorkerApiClient("", nil), logger),
+		workerPool: &workerPool{
+			inProgressLeases:     map[string]string{},
+			inProgressLeasesLock: sync.Mutex{},
+		},
+	}
+	h.startConnection = func(_ context.Context, _ connectionEstablishData, opts ...connectOpt) {
+		defer close(replacementFinished)
+
+		o := connectOpts{}
+		for _, opt := range opts {
+			opt(&o)
+		}
+
+		close(replacementStarted)
+		<-releaseReplacement
+
+		if o.notifyConnectedChan != nil {
+			o.notifyConnectedChan <- struct{}{}
+			close(o.notifyConnectedChan)
+		}
+	}
+
+	preparedConn := &connection{
+		ws:                clientConn,
+		gatewayGroupName:  "old-gateway",
+		connectionId:      "old-connection",
+		heartbeatInterval: time.Hour,
+	}
+	activateTestConnection(t, preparedConn)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.handleConnection(ctx, connectionEstablishData{}, preparedConn)
+	}()
+
+	select {
+	case <-replacementStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for replacement connection attempt")
+	}
+
+	select {
+	case err := <-done:
+		r.ErrorIs(err, errGatewayDraining)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for replacement timeout")
+	}
+
+	close(releaseReplacement)
+
+	select {
+	case <-replacementFinished:
+	case <-time.After(time.Second):
+		t.Fatal("late replacement notification blocked")
+	}
+}
+
 func TestHandleInvokeMessageAttemptsReplyDuringDrainForAckedWork(t *testing.T) {
 	r := require.New(t)
 

--- a/connect/connection_drain_test.go
+++ b/connect/connection_drain_test.go
@@ -29,6 +29,8 @@ func TestHandleConnectionGatewayClosingDrainsUntilReplacementConnected(t *testin
 		defer close(serverDone)
 		defer func() { _ = conn.CloseNow() }()
 
+		// Simulate the gateway asking this generation to drain while keeping
+		// the old transport open for allowed in-flight replies.
 		r.NoError(wsproto.Write(context.Background(), conn, &connectproto.ConnectMessage{
 			Kind: connectproto.GatewayMessageType_GATEWAY_CLOSING,
 		}))
@@ -62,6 +64,8 @@ func TestHandleConnectionGatewayClosingDrainsUntilReplacementConnected(t *testin
 		},
 	}
 	h.startConnection = func(_ context.Context, _ connectionEstablishData, opts ...connectOpt) {
+		// Hold replacement completion so the test can observe the old
+		// generation in Draining before it is retired.
 		o := connectOpts{}
 		for _, opt := range opts {
 			opt(&o)
@@ -101,6 +105,8 @@ func TestHandleConnectionGatewayClosingDrainsUntilReplacementConnected(t *testin
 	r.False(preparedConn.canWriteRequestAck())
 	r.True(preparedConn.canWriteReply())
 
+	// Once the replacement reports connected, the old generation should retire
+	// and close through lifecycle helpers.
 	close(releaseReplacement)
 
 	select {
@@ -138,6 +144,8 @@ func TestHandleConnectionGatewayClosingRetiresAndClosesAfterReplacementTimeout(t
 		defer close(serverDone)
 		defer func() { _ = conn.CloseNow() }()
 
+		// The server keeps the socket readable so close completion is driven by
+		// the SDK replacement timeout, not by a peer-side close race.
 		r.NoError(wsproto.Write(context.Background(), conn, &connectproto.ConnectMessage{
 			Kind: connectproto.GatewayMessageType_GATEWAY_CLOSING,
 		}))
@@ -170,6 +178,8 @@ func TestHandleConnectionGatewayClosingRetiresAndClosesAfterReplacementTimeout(t
 		},
 	}
 	h.startConnection = func(context.Context, connectionEstablishData, ...connectOpt) {
+		// Start but never notify connection success; handleConnection should
+		// bound the drain with gatewayDrainReplacementTimeout.
 		close(replacementStarted)
 	}
 
@@ -261,6 +271,8 @@ func TestHandleConnectionGatewayClosingLateReplacementNotificationDoesNotBlock(t
 	h.startConnection = func(_ context.Context, _ connectionEstablishData, opts ...connectOpt) {
 		defer close(replacementFinished)
 
+		// Notify after handleConnection has already timed out. The buffered
+		// notification channel must prevent this goroutine from blocking.
 		o := connectOpts{}
 		for _, opt := range opts {
 			opt(&o)
@@ -301,6 +313,8 @@ func TestHandleConnectionGatewayClosingLateReplacementNotificationDoesNotBlock(t
 		t.Fatal("timed out waiting for replacement timeout")
 	}
 
+	// Releasing the delayed replacement after timeout verifies the notification
+	// send is still non-blocking.
 	close(releaseReplacement)
 
 	select {
@@ -391,6 +405,8 @@ func TestHandleInvokeMessageAttemptsReplyDuringDrainForAckedWork(t *testing.T) {
 		t.Fatal("server did not receive worker request ack")
 	}
 
+	// After ACK, the request remains owned by this generation. Draining should
+	// still permit the reply write before the generation is retired.
 	r.NoError(preparedConn.beginDrain("test"))
 	close(release)
 
@@ -488,6 +504,8 @@ func TestHandleInvokeMessageBuffersDrainingReplyWriteFailure(t *testing.T) {
 		t.Fatal("server did not receive worker request ack")
 	}
 
+	// Draining allows the reply attempt; forcing the transport closed proves a
+	// failed draining write buffers the response without retiring here.
 	r.NoError(preparedConn.beginDrain("test"))
 	_ = clientConn.CloseNow()
 	close(release)

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -714,38 +714,38 @@ Purpose: make worker-initiated graceful shutdown distinct from gateway drain.
 
 *** Implementation checklist
 
-- [ ] Add =Closing= as a first-class websocket generation state.
-- [ ] Move graceful shutdown behavior through =beginClose=.
-- [ ] Send =WORKER_PAUSE= when entering =Closing=.
-- [ ] Stop new request ACKs in =Closing=.
-- [ ] Allow already-ACKed in-flight work to finish in =Closing=.
-- [ ] Attempt =WORKER_REPLY= for already-ACKed in-flight work while
+- [X] Add =Closing= as a first-class websocket generation state.
+- [X] Move graceful shutdown behavior through =beginClose=.
+- [X] Send =WORKER_PAUSE= when entering =Closing=.
+- [X] Stop new request ACKs in =Closing=.
+- [X] Allow already-ACKed in-flight work to finish in =Closing=.
+- [X] Attempt =WORKER_REPLY= for already-ACKed in-flight work while
   =Closing=.
-- [ ] Buffer reply if the closing websocket write fails.
-- [ ] Move from =Closing= to =Retired= after worker-pool completion.
-- [ ] Close the transport through lifecycle close helpers.
-- [ ] Add comments near graceful shutdown handling clarifying that =Closing= is
+- [X] Buffer reply if the closing websocket write fails.
+- [X] Move from =Closing= to =Retired= after worker-pool completion.
+- [X] Close the transport through lifecycle close helpers.
+- [X] Add comments near graceful shutdown handling clarifying that =Closing= is
   local worker shutdown, not gateway-initiated replacement.
 
 *** Test checklist
 
-- [ ] Graceful shutdown moves active generation to =Closing= before
+- [X] Graceful shutdown moves active generation to =Closing= before
   =Retired=.
-- [ ] Entering =Closing= sends =WORKER_PAUSE=.
-- [ ] Queued pre-ACK work does not start in =Closing=.
-- [ ] ACKed in-flight work can finish in =Closing=.
-- [ ] ACKed in-flight reply attempts websocket first and buffers on failure.
-- [ ] Generation moves to =Retired= and =Closed= after worker-pool completion.
+- [X] Entering =Closing= sends =WORKER_PAUSE=.
+- [X] Queued pre-ACK work does not start in =Closing=.
+- [X] ACKed in-flight work can finish in =Closing=.
+- [X] ACKed in-flight reply attempts websocket first and buffers on failure.
+- [X] Generation moves to =Retired= and =Closed= after worker-pool completion.
 
 *** Validation checklist
 
-- [ ] =go test ./connect -count=1=
-- [ ] Tests distinguish =Draining= and =Closing= behavior.
+- [X] =go test ./connect -count=1=
+- [X] Tests distinguish =Draining= and =Closing= behavior.
 
 *** Exit criteria
 
-- [ ] Gateway drain and graceful shutdown have separate phases and comments.
-- [ ] Shutdown side effects are correlated with entering =Closing=.
+- [X] Gateway drain and graceful shutdown have separate phases and comments.
+- [X] Shutdown side effects are correlated with entering =Closing=.
 
 ** Phase 4: Clarify manager transitions
 

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -670,42 +670,42 @@ worker shutdown.
 
 *** Implementation checklist
 
-- [ ] Move =GATEWAY_CLOSING= handling through =beginDrain=.
-- [ ] Preserve replacement-connection-before-close behavior.
-- [ ] Keep the old generation open during drain only for explicitly allowed
+- [X] Move =GATEWAY_CLOSING= handling through =beginDrain=.
+- [X] Preserve replacement-connection-before-close behavior.
+- [X] Keep the old generation open during drain only for explicitly allowed
   operations.
-- [ ] Move old generation from =Draining= to =Retired= after:
-  - [ ] replacement connection is established; or
-  - [ ] replacement wait times out.
-- [ ] Close the old transport through lifecycle close helpers.
-- [ ] Implement =Draining= reply policy:
-  - [ ] attempt =WORKER_REPLY= for already-ACKed in-flight work;
-  - [ ] buffer reply if the draining websocket write fails;
-  - [ ] buffer immediately once the generation reaches =Retired=.
-- [ ] Stop heartbeat writes immediately when the generation enters
+- [X] Move old generation from =Draining= to =Retired= after:
+  - [X] replacement connection is established; or
+  - [X] replacement wait times out.
+- [X] Close the old transport through lifecycle close helpers.
+- [X] Implement =Draining= reply policy:
+  - [X] attempt =WORKER_REPLY= for already-ACKed in-flight work;
+  - [X] buffer reply if the draining websocket write fails;
+  - [X] buffer immediately once the generation reaches =Retired=.
+- [X] Stop heartbeat writes immediately when the generation enters
   =Draining=.
-- [ ] Add comments near drain handling clarifying that =Draining= is
+- [X] Add comments near drain handling clarifying that =Draining= is
   gateway-initiated replacement, not local worker shutdown.
 
 *** Test checklist
 
-- [ ] =GATEWAY_CLOSING= moves old generation to =Draining=.
-- [ ] Replacement connection can become =Active= while old generation is still
+- [X] =GATEWAY_CLOSING= moves old generation to =Draining=.
+- [X] Replacement connection can become =Active= while old generation is still
   =Draining=.
-- [ ] Old generation moves to =Retired= and =Closed= after replacement.
-- [ ] Old generation moves to =Retired= and =Closed= after replacement timeout.
-- [ ] Queued work after drain does not start if ACK cannot be sent.
-- [ ] In-flight ACKed work follows the chosen =Draining= reply policy.
+- [X] Old generation moves to =Retired= and =Closed= after replacement.
+- [X] Old generation moves to =Retired= and =Closed= after replacement timeout.
+- [X] Queued work after drain does not start if ACK cannot be sent.
+- [X] In-flight ACKed work follows the chosen =Draining= reply policy.
 
 *** Validation checklist
 
-- [ ] =go test ./connect -count=1=
-- [ ] Drain tests do not depend on real websocket close races.
+- [X] =go test ./connect -count=1=
+- [X] Drain tests do not depend on real websocket close races.
 
 *** Exit criteria
 
-- [ ] Gateway drain behavior is explicit and separately testable.
-- [ ] Manager can be =ACTIVE= while an old generation is =DRAINING= or
+- [X] Gateway drain behavior is explicit and separately testable.
+- [X] Manager can be =ACTIVE= while an old generation is =DRAINING= or
   =RETIRED=.
 
 ** Phase 3.5: Model graceful websocket closing explicitly


### PR DESCRIPTION
## Summary

- model `GATEWAY_CLOSING` as an explicit `Draining` generation phase
- keep drained generations open only for allowed in-flight writes, then retire and close after replacement success or timeout
- model graceful worker shutdown as `Closing`, wait for worker-pool completion, then retire before transport close
- add drain and closing regression tests for ACK gating, in-flight replies, reply buffering, heartbeat/pause behavior, and late replacement notification
- mark plan 000 phases 3 and 3.5 complete

## Testing

- `go test ./connect -count=1`