### PR TITLE
fix(connect): harden websocket lifecycle boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,4 @@ with Inngest step primitives from Go code.
   consistent.
 - Commit in small logical chunks so each commit is self-reviewable.
 - If working with a plan, update checklist statuses as you go.
+- Add comments to clarify intent

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -82,7 +82,8 @@ func (h *connectHandler) connect(ctx context.Context, data connectionEstablishDa
 		l.Error("could not handle connection", "err", err, "reconnect", shouldReconnect(err))
 
 		if errors.Is(err, errGatewayDraining) {
-			// if the gateway is draining, the original connection was closed, and we already reconnected inside handleConnection
+			// Gateway drain owns its replacement and old-generation close work
+			// inside handleConnection; the manager loop remains ACTIVE.
 			return
 		}
 
@@ -217,8 +218,10 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 	l := h.logger.With(preparedConn.logAttrs()...)
 
 	defer func() {
-		// This is a fallback safeguard to always close the WebSocket connection at the end of the function
-		// Usually, we provide a specific reason, so this is only necessary for unhandled errors
+		// Fallback safeguard for exits that do not reach the explicit drain,
+		// shutdown, or read-error close paths. closeNow is idempotent, so this
+		// does not duplicate side effects after a lifecycle helper already
+		// closed the transport.
 		preparedConn.closeNow("handle connection ended")
 	}()
 
@@ -357,9 +360,9 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 
 	l.Debug("waiting for read loop to end")
 
-	// If read loop ends, this can be for two reasons
-	// - Connection loss (io.EOF), read loop terminated intentionally (CloseError), other error (unexpected), missed heartbeat (readerLifetimeContext canceled)
-	// - Worker shutdown, parent context got cancelled
+	// When the read loop exits before local shutdown, the websocket generation
+	// is no longer a reliable writer. Gateway drain is the one exception: it
+	// keeps this generation in Draining while a replacement connects.
 	if err := eg.Wait(); err != nil && ctx.Err() == nil {
 		if errors.Is(err, errGatewayDraining) {
 			// Gateway is draining this generation. Establish a replacement on
@@ -382,6 +385,9 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 		}
 
 		l.Debug("read loop ended with error", "err", err)
+		// Unexpected read termination retires the generation before the manager
+		// decides whether to reconnect. That prevents queued request work from
+		// attempting stale ACKs on this websocket.
 		preparedConn.retire("read loop ended with error", "err", err)
 
 		// In case the gateway intentionally closed the connection, we'll receive a close error
@@ -439,7 +445,8 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 
 	preparedConn.retire("worker pool drained")
 
-	// Attempt to shut down connection if not already done
+	// Close through the lifecycle helper after the worker pool drains. The
+	// deferred closeNow remains only as a fallback for unhandled exits.
 	preparedConn.closeNormal(connectproto.WorkerDisconnectReason_WORKER_SHUTDOWN.String(), "reason", "worker shutdown")
 
 	// Attempt to flush leftover messages before closing

--- a/connect/connection_closing_test.go
+++ b/connect/connection_closing_test.go
@@ -98,7 +98,6 @@ func TestHandleConnectionGracefulShutdownEntersClosingBeforeRetireAndClose(t *te
 	}
 
 	r.Equal(connPhaseClosed, preparedConn.phase())
-	r.True(preparedConn.isRetired())
 
 	select {
 	case <-serverDone:
@@ -346,7 +345,7 @@ func TestHandleInvokeMessageBuffersClosingReplyWriteFailure(t *testing.T) {
 		t.Fatal("timed out waiting for invoke")
 	}
 
-	r.False(preparedConn.isRetired())
+	r.Equal(connPhaseClosing, preparedConn.phase())
 
 	h.messageBuffer.lock.Lock()
 	defer h.messageBuffer.lock.Unlock()

--- a/connect/connection_drain_test.go
+++ b/connect/connection_drain_test.go
@@ -117,7 +117,6 @@ func TestHandleConnectionGatewayClosingDrainsUntilReplacementConnected(t *testin
 	}
 
 	r.Equal(connPhaseClosed, preparedConn.phase())
-	r.True(preparedConn.isRetired())
 
 	select {
 	case <-serverDone:
@@ -210,7 +209,6 @@ func TestHandleConnectionGatewayClosingRetiresAndClosesAfterReplacementTimeout(t
 	}
 
 	r.Equal(connPhaseClosed, preparedConn.phase())
-	r.True(preparedConn.isRetired())
 
 	select {
 	case <-serverDone:
@@ -517,7 +515,7 @@ func TestHandleInvokeMessageBuffersDrainingReplyWriteFailure(t *testing.T) {
 		t.Fatal("timed out waiting for invoke")
 	}
 
-	r.False(preparedConn.isRetired())
+	r.Equal(connPhaseDraining, preparedConn.phase())
 
 	h.messageBuffer.lock.Lock()
 	defer h.messageBuffer.lock.Unlock()

--- a/connect/connection_lifecycle.go
+++ b/connect/connection_lifecycle.go
@@ -130,15 +130,6 @@ func (c *connection) closeNow(reason string, attrs ...any) bool {
 	return true
 }
 
-func (c *connection) isRetired() bool {
-	switch c.phase() {
-	case connPhaseRetired, connPhaseClosed:
-		return true
-	default:
-		return false
-	}
-}
-
 // transition applies a validated phase change and its lifecycle side effects.
 // All phase mutations go through this path so write permissions, no-write
 // notification, manager flush notification, and transition logs stay coupled.

--- a/connect/connection_lifecycle_test.go
+++ b/connect/connection_lifecycle_test.go
@@ -17,7 +17,6 @@ func TestConnectionLifecycleNewHandshakingActive(t *testing.T) {
 	r.NoError(conn.transition(connPhaseHandshaking, "dialed"))
 	r.NoError(conn.markActive("ready"))
 	r.Equal(connPhaseActive, conn.phase())
-	r.False(conn.isRetired())
 }
 
 func TestConnectionLifecycleRetireDisablesWritesAndNotifiesFlush(t *testing.T) {
@@ -30,7 +29,6 @@ func TestConnectionLifecycleRetireDisablesWritesAndNotifiesFlush(t *testing.T) {
 
 	r.True(conn.retire("read failed"))
 	r.Equal(connPhaseRetired, conn.phase())
-	r.True(conn.isRetired())
 
 	select {
 	case <-flushNotify:
@@ -54,7 +52,6 @@ func TestConnectionLifecycleDrainAndCloseTransitions(t *testing.T) {
 	r.Equal(connPhaseRetired, conn.phase())
 	r.True(conn.closeNow("done"))
 	r.Equal(connPhaseClosed, conn.phase())
-	r.True(conn.isRetired())
 	r.False(conn.closeNow("again"))
 }
 
@@ -81,7 +78,6 @@ func TestConnectionLifecycleActiveToClosedAppliesRetireEffects(t *testing.T) {
 
 	r.True(conn.closeNow("transport closed"))
 	r.Equal(connPhaseClosed, conn.phase())
-	r.True(conn.isRetired())
 
 	select {
 	case <-flushNotify:

--- a/connect/connection_write.go
+++ b/connect/connection_write.go
@@ -3,8 +3,8 @@ package connect
 import connectproto "github.com/inngest/inngest/proto/gen/connect/v1"
 
 // These helpers centralize websocket write policy for one connection
-// generation. Phase 2 keeps request behavior unchanged; it only makes each
-// protocol write ask lifecycle state before attempting the websocket write.
+// generation. Every non-handshake protocol write should pass through this
+// phase policy before attempting to use the websocket.
 func (c *connection) canWriteHeartbeat() bool {
 	return c.canWrite(connectproto.GatewayMessageType_WORKER_HEARTBEAT)
 }

--- a/connect/connection_write_test.go
+++ b/connect/connection_write_test.go
@@ -76,6 +76,9 @@ func TestHandleInvokeMessageSkipsAckWhenPhaseDisallowsAck(t *testing.T) {
 		messageBuffer: newMessageBuffer(apiClient, logger),
 	}
 	preparedConn := newLifecycleTestConnection(nil)
+	preparedConn.connectionId = "test-connection"
+	preparedConn.gatewayGroupName = "test-group"
+	preparedConn.gatewayEndpoint = "wss://test-gateway"
 	r.NoError(preparedConn.transition(connPhaseHandshaking, "test"))
 	r.NoError(preparedConn.markActive("test"))
 	r.NoError(preparedConn.beginDrain("test"))
@@ -94,6 +97,8 @@ func TestHandleInvokeMessageSkipsAckWhenPhaseDisallowsAck(t *testing.T) {
 	r.NoError(err)
 	r.False(invoker.called.Load())
 	r.Contains(logOutput.String(), "phase does not allow request ack")
+	r.Contains(logOutput.String(), "phase=Draining")
+	r.Contains(logOutput.String(), "connection_id=test-connection")
 	r.NotContains(logOutput.String(), "error sending request ack")
 }
 

--- a/connect/connection_write_test.go
+++ b/connect/connection_write_test.go
@@ -275,7 +275,7 @@ func TestHandleInvokeMessageBuffersReplyWriteFailureWithoutRetiringConnection(t 
 		t.Fatal("timed out waiting for invoke")
 	}
 
-	r.False(preparedConn.isRetired())
+	r.Equal(connPhaseActive, preparedConn.phase())
 
 	h.messageBuffer.lock.Lock()
 	defer h.messageBuffer.lock.Unlock()

--- a/connect/handler.go
+++ b/connect/handler.go
@@ -354,7 +354,12 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 					}
 				}
 
-				h.setState(ConnectionStateReconnecting, "connection ended with reconnect", "err", msg.err, "attempt", attempts)
+				// Until the first successful websocket, retrying is still
+				// startup; RECONNECTING is reserved for restoring an
+				// established worker connection.
+				if !isInitialConnection {
+					h.setState(ConnectionStateReconnecting, "connection ended with reconnect", "err", msg.err, "attempt", attempts)
+				}
 
 				// Attempt to flush messages before reconnecting.
 				h.flushBufferedMessages("before reconnect")

--- a/connect/handler.go
+++ b/connect/handler.go
@@ -35,8 +35,11 @@ const (
 type ConnectionState string
 
 const (
-	ConnectionStateConnecting   ConnectionState = "CONNECTING"
-	ConnectionStateActive       ConnectionState = "ACTIVE"
+	ConnectionStateConnecting ConnectionState = "CONNECTING"
+	ConnectionStateActive     ConnectionState = "ACTIVE"
+	// ConnectionStatePaused is retained for source compatibility. The manager
+	// no longer enters PAUSED; local shutdown is CLOSING and websocket
+	// generation pause writes are modeled separately.
 	ConnectionStatePaused       ConnectionState = "PAUSED"
 	ConnectionStateReconnecting ConnectionState = "RECONNECTING"
 	ConnectionStateClosing      ConnectionState = "CLOSING"
@@ -284,14 +287,13 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 					return err
 				}
 
-				h.setState(ConnectionStateReconnecting, "connection ended with reconnect", "err", msg.err, "attempt", attempts)
-
 				// Some errors should be handled differently (e.g. auth failed)
 				if msg.err != nil {
 					if errors.Is(msg.err, ErrTooManyConnections) {
 						// If limits are exceed in initial connection, return immediately
 						if isInitialConnection {
 							err := fmt.Errorf("too many connections, please disconnect other workers or upgrade your billing plan for more concurrent connections")
+							h.setState(ConnectionStateClosed, "too many connections", "err", msg.err)
 							isInitialConnection = false
 							initialConnectionDone <- err
 							return err
@@ -301,6 +303,7 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 					if errors.Is(msg.err, ErrUnauthenticated) {
 						if h.auth.fallback {
 							err := fmt.Errorf("failed to authenticate with fallback key, exiting")
+							h.setState(ConnectionStateClosed, "fallback authentication failed", "err", msg.err)
 							if isInitialConnection {
 								isInitialConnection = false
 								initialConnectionDone <- err
@@ -313,6 +316,7 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 
 						if len(signingKeyFallback) == 0 {
 							err := fmt.Errorf("fallback signing key is required")
+							h.setState(ConnectionStateClosed, "fallback signing key missing", "err", msg.err)
 
 							if isInitialConnection {
 								isInitialConnection = false
@@ -344,18 +348,16 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 							}
 
 							// If we received a reason that's non-retriable, stop here.
+							h.setState(ConnectionStateClosed, "non-reconnectable close reason", "err", msg.err)
 							return fmt.Errorf("connect failed with error code %q", closeErr.Reason)
 						}
 					}
 				}
 
-				// Attempt to flush messages before reconnecting
-				if h.messageBuffer.hasMessages() {
-					err := h.messageBuffer.flush(h.auth.hashedSigningKey)
-					if err != nil {
-						l.Error("could not send buffered messages", "err", err)
-					}
-				}
+				h.setState(ConnectionStateReconnecting, "connection ended with reconnect", "err", msg.err, "attempt", attempts)
+
+				// Attempt to flush messages before reconnecting.
+				h.flushBufferedMessages("before reconnect")
 
 				// continue to reconnect logic
 				reconnectBackoff := h.reconnectBackoff
@@ -380,6 +382,12 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 				}
 
 			case <-h.initiateConnectionChan:
+			case <-h.notifyFlushChan:
+				// Lifecycle retire notifications are coalesced by the buffered
+				// channel and serialized here in the manager loop. Reconnect and
+				// shutdown still flush explicitly as safety points.
+				h.flushBufferedMessages("lifecycle notification")
+				continue
 			}
 
 			if attempts == 5 {
@@ -435,16 +443,8 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 			l.Debug("got connection done signal")
 		}
 
-		// Always send out buffered messages using API
-		if h.messageBuffer.hasMessages() {
-			// Send buffered messages
-			err := h.messageBuffer.flush(h.auth.hashedSigningKey)
-			if err != nil {
-				l.Error("could not send buffered messages", "err", err)
-			}
-
-			// TODO Push remaining messages to another destination for processing?
-		}
+		// Always send out buffered messages using API.
+		h.flushBufferedMessages("connect handler closing")
 
 		l.Debug("connect handler done")
 		return nil
@@ -499,21 +499,6 @@ func (h *connectHandler) State() ConnectionState {
 	h.stateLock.RLock()
 	defer h.stateLock.RUnlock()
 	return h.state
-}
-
-func (h *connectHandler) setState(state ConnectionState, reason string, attrs ...any) {
-	h.stateLock.Lock()
-	previous := h.state
-	h.state = state
-	h.stateLock.Unlock()
-
-	logAttrs := []any{
-		"from", previous,
-		"to", state,
-		"reason", reason,
-	}
-	logAttrs = append(logAttrs, attrs...)
-	h.logger.Debug("worker connection state transition", logAttrs...)
 }
 
 var errGatewayDraining = errors.New("gateway is draining")

--- a/connect/handler_test.go
+++ b/connect/handler_test.go
@@ -330,6 +330,7 @@ func TestConnectNonReconnectableCloseReasonStopsManager(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for Connect to return")
 	}
+	r.Equal(ConnectionStateClosed, h.State())
 
 	select {
 	case <-started:

--- a/connect/handler_test.go
+++ b/connect/handler_test.go
@@ -1016,7 +1016,7 @@ func TestHandleConnectionGracefulShutdownPausesDrainsAndFlushes(t *testing.T) {
 		t.Fatal("timed out waiting for handleConnection")
 	}
 
-	r.True(preparedConn.isRetired())
+	r.Equal(connPhaseClosed, preparedConn.phase())
 
 	select {
 	case resp := <-flushSeen:
@@ -1221,7 +1221,7 @@ func TestHandleInvokeMessageRetiresConnectionAfterAckWriteFailure(t *testing.T) 
 	err = h.handleInvokeMessage(context.Background(), preparedConn, firstMsg)
 	r.Error(err)
 	r.Contains(err.Error(), "could not write message to websocket")
-	r.True(preparedConn.isRetired())
+	r.Equal(connPhaseRetired, preparedConn.phase())
 	r.False(invoker.called.Load())
 
 	secondMsg := mustExecutorRequestMessage(t, &connectproto.GatewayExecutorRequestData{
@@ -1247,7 +1247,7 @@ func TestConnectionRetireIsIdempotent(t *testing.T) {
 
 	r.True(conn.retire("test"))
 	r.False(conn.retire("test"))
-	r.True(conn.isRetired())
+	r.Equal(connPhaseRetired, conn.phase())
 }
 
 type blockingTestInvoker struct {

--- a/connect/invoke.go
+++ b/connect/invoke.go
@@ -31,9 +31,10 @@ func (h *connectHandler) handleInvokeMessage(ctx context.Context, preparedConn *
 		if errors.Is(err, errConnectionRetired) {
 			// This is a pre-ACK skip. Once ACK succeeds, connectInvoke invokes
 			// the function with context.Background() and must let it finish.
+			logAttrs := append(preparedConn.logAttrs(), "phase", preparedConn.phase())
 			h.logger.Debug(
 				"skipping sdk request because connection phase does not allow request ack",
-				"phase", preparedConn.phase(),
+				logAttrs...,
 			)
 			return nil
 		}
@@ -59,29 +60,7 @@ func (h *connectHandler) handleInvokeMessage(ctx context.Context, preparedConn *
 	// that the message was truly passed on to the executor _unless_ we receive the ack message.
 	h.messageBuffer.addPending(ctx, resp, ResponseAcknowlegeDeadline)
 
-	if !preparedConn.canWriteReply() {
-		h.messageBuffer.append(resp)
-		h.logger.Debug(
-			"buffering sdk response because connection phase does not allow reply write",
-			"request_id", resp.RequestId,
-			"phase", preparedConn.phase(),
-		)
-		return nil
-	}
-
-	err = wsproto.Write(ctx, preparedConn.ws, responseMessage)
-	if err != nil {
-		// We received an error, the message definitely was not sent: Buffer message to retry
-		// Phase 2 preserves the existing policy: reply write failure does not retire
-		// the generation. The ACKed function has already completed, so the reply is
-		// buffered for API flush and connection retirement remains a separate decision.
-		h.messageBuffer.append(resp)
-		h.logger.Debug("buffering sdk response after websocket write failure", "err", err, "request_id", resp.RequestId)
-
-		return nil
-	}
-
-	return nil
+	return h.writeReply(ctx, preparedConn, resp, responseMessage)
 }
 
 // connectInvoke is the counterpart to invoke for connect
@@ -102,6 +81,7 @@ func (h *connectHandler) connectInvoke(ctx context.Context, preparedConn *connec
 		"app_id", body.AppId,
 		"function_slug", body.FunctionSlug,
 	}
+	logAttrs = append(logAttrs, preparedConn.logAttrs()...)
 	l := h.logger.With(logAttrs...)
 
 	invoker, ok := h.invokers[body.AppName]
@@ -139,18 +119,8 @@ func (h *connectHandler) connectInvoke(ctx context.Context, preparedConn *connec
 		return nil, publicerr.Wrap(err, 400, "malformed input")
 	}
 
-	// ACK is the ownership boundary. If this generation is already retired,
-	// do not ACK and do not invoke; the gateway/executor can retry elsewhere.
-	if !preparedConn.canWriteRequestAck() {
-		return nil, errConnectionRetired
-	}
-	if err := wsproto.Write(ctx, preparedConn.ws, &connectproto.ConnectMessage{
-		Kind:    connectproto.GatewayMessageType_WORKER_REQUEST_ACK,
-		Payload: ackPayload,
-	}); err != nil {
-		preparedConn.retire("request ack write failed", "err", err)
-		l.Error("error sending request ack", "error", err)
-		return nil, publicerr.Wrap(err, 400, "failed to ack worker request")
+	if err := h.writeRequestAck(ctx, preparedConn, ackPayload, l); err != nil {
+		return nil, err
 	}
 
 	// TODO Should we wait for a gateway response before starting to process? What if the gateway fails acking and we start too early?
@@ -201,9 +171,10 @@ func (h *connectHandler) connectInvoke(ctx context.Context, preparedConn *connec
 				cancelExtendLeaseCtx()
 				return
 			}
-			if !preparedConn.canWriteExtendLease() {
+			if !canExtendRequestLease(preparedConn) {
 				// ACKed work remains owned through Draining and Closing, so this
 				// only stops at the hard no-write boundary: Retired or Closed.
+				l.Debug("stopping lease extension because connection phase does not allow lease extension", "phase", preparedConn.phase())
 				cancelExtendLeaseCtx()
 				return
 			}

--- a/connect/manager_flush.go
+++ b/connect/manager_flush.go
@@ -1,0 +1,14 @@
+package connect
+
+func (h *connectHandler) flushBufferedMessages(reason string) {
+	// Flushes are manager-owned because they need the current auth context.
+	// Websocket generations only send a best-effort notification when their
+	// lifecycle reaches a no-write phase.
+	if h.messageBuffer == nil || !h.messageBuffer.hasMessages() {
+		return
+	}
+
+	if err := h.messageBuffer.flush(h.auth.hashedSigningKey); err != nil {
+		h.logger.Error("could not send buffered messages", "err", err, "reason", reason)
+	}
+}

--- a/connect/manager_flush_test.go
+++ b/connect/manager_flush_test.go
@@ -1,0 +1,169 @@
+package connect
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	connectproto "github.com/inngest/inngest/proto/gen/connect/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestManagerFlushNotificationFlushesWithCurrentAuth(t *testing.T) {
+	r := require.New(t)
+
+	flushSeen := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal("/v0/connect/flush", req.URL.Path)
+		r.Equal("Bearer signing-key", req.Header.Get("Authorization"))
+
+		body, err := io.ReadAll(req.Body)
+		r.NoError(err)
+
+		var resp connectproto.SDKResponse
+		r.NoError(proto.Unmarshal(body, &resp))
+		r.Equal("request-id", resp.RequestId)
+
+		payload, err := proto.Marshal(&connectproto.FlushResponse{})
+		r.NoError(err)
+		w.Header().Set("Content-Type", "application/protobuf")
+		_, _ = w.Write(payload)
+		close(flushSeen)
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.DiscardHandler)
+	apiClient := newWorkerApiClient(server.URL, nil)
+	h := &connectHandler{
+		opts:                   Opts{IsDev: true, HashedSigningKey: []byte("signing-key")},
+		logger:                 logger,
+		notifyConnectDoneChan:  make(chan connectReport),
+		notifyConnectedChan:    make(chan struct{}),
+		initiateConnectionChan: make(chan struct{}, 1),
+		notifyFlushChan:        make(chan struct{}, 1),
+		apiClient:              apiClient,
+		messageBuffer:          newMessageBuffer(apiClient, logger),
+		state:                  ConnectionStateConnecting,
+	}
+	h.startConnection = func(context.Context, connectionEstablishData, ...connectOpt) {
+		h.notifyConnectedChan <- struct{}{}
+	}
+	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())
+	defer h.cancelWorkerCtx()
+
+	connectCtx, cancelConnect := context.WithCancel(context.Background())
+	defer cancelConnect()
+
+	_, err := h.Connect(connectCtx)
+	r.NoError(err)
+
+	h.messageBuffer.append(&connectproto.SDKResponse{
+		RequestId: "request-id",
+	})
+	// The lifecycle only notifies; the manager owns the API flush and applies
+	// the current auth context.
+	h.notifyFlushChan <- struct{}{}
+
+	select {
+	case <-flushSeen:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for lifecycle flush")
+	}
+
+	r.False(h.messageBuffer.hasMessages())
+	cancelConnect()
+	r.NoError(h.Close())
+}
+
+func TestManagerFlushNotificationsAreSerialized(t *testing.T) {
+	r := require.New(t)
+
+	firstFlushStarted := make(chan struct{})
+	releaseFlush := make(chan struct{})
+	var activeFlushes atomic.Int32
+	var maxActiveFlushes atomic.Int32
+	var flushCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// The manager run loop should serialize flushes, so this counter must
+		// never observe two active /flush requests at once.
+		current := activeFlushes.Add(1)
+		defer activeFlushes.Add(-1)
+
+		for {
+			max := maxActiveFlushes.Load()
+			if current <= max || maxActiveFlushes.CompareAndSwap(max, current) {
+				break
+			}
+		}
+
+		if flushCount.Add(1) == 1 {
+			close(firstFlushStarted)
+			<-releaseFlush
+		}
+
+		payload, err := proto.Marshal(&connectproto.FlushResponse{})
+		r.NoError(err)
+		w.Header().Set("Content-Type", "application/protobuf")
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.DiscardHandler)
+	apiClient := newWorkerApiClient(server.URL, nil)
+	h := &connectHandler{
+		opts:                   Opts{IsDev: true, HashedSigningKey: []byte("signing-key")},
+		logger:                 logger,
+		notifyConnectDoneChan:  make(chan connectReport),
+		notifyConnectedChan:    make(chan struct{}),
+		initiateConnectionChan: make(chan struct{}, 1),
+		notifyFlushChan:        make(chan struct{}, 1),
+		apiClient:              apiClient,
+		messageBuffer:          newMessageBuffer(apiClient, logger),
+		state:                  ConnectionStateConnecting,
+	}
+	h.startConnection = func(context.Context, connectionEstablishData, ...connectOpt) {
+		h.notifyConnectedChan <- struct{}{}
+	}
+	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())
+	defer h.cancelWorkerCtx()
+
+	connectCtx, cancelConnect := context.WithCancel(context.Background())
+	defer cancelConnect()
+
+	_, err := h.Connect(connectCtx)
+	r.NoError(err)
+
+	h.messageBuffer.append(&connectproto.SDKResponse{RequestId: "request-1"})
+	h.messageBuffer.append(&connectproto.SDKResponse{RequestId: "request-2"})
+
+	// Send one notification while the first flush is blocked, then attempt a
+	// second notification. The channel may coalesce it, but it must not start a
+	// concurrent flush.
+	h.notifyFlushChan <- struct{}{}
+	select {
+	case <-firstFlushStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first lifecycle flush")
+	}
+
+	select {
+	case h.notifyFlushChan <- struct{}{}:
+	default:
+	}
+	close(releaseFlush)
+
+	r.Eventually(func() bool {
+		return !h.messageBuffer.hasMessages()
+	}, time.Second, time.Millisecond)
+
+	r.Equal(int32(1), maxActiveFlushes.Load())
+	cancelConnect()
+	r.NoError(h.Close())
+}

--- a/connect/manager_flush_test.go
+++ b/connect/manager_flush_test.go
@@ -167,3 +167,78 @@ func TestManagerFlushNotificationsAreSerialized(t *testing.T) {
 	cancelConnect()
 	r.NoError(h.Close())
 }
+
+func TestLateRetiredReplySchedulesManagerFlush(t *testing.T) {
+	r := require.New(t)
+
+	flushSeen := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		r.Equal("/v0/connect/flush", req.URL.Path)
+
+		body, err := io.ReadAll(req.Body)
+		r.NoError(err)
+
+		var resp connectproto.SDKResponse
+		r.NoError(proto.Unmarshal(body, &resp))
+		r.Equal("late-request-id", resp.RequestId)
+
+		payload, err := proto.Marshal(&connectproto.FlushResponse{})
+		r.NoError(err)
+		w.Header().Set("Content-Type", "application/protobuf")
+		_, _ = w.Write(payload)
+		close(flushSeen)
+	}))
+	defer server.Close()
+
+	logger := slog.New(slog.DiscardHandler)
+	apiClient := newWorkerApiClient(server.URL, nil)
+	h := &connectHandler{
+		opts:                   Opts{IsDev: true, HashedSigningKey: []byte("signing-key")},
+		logger:                 logger,
+		notifyConnectDoneChan:  make(chan connectReport),
+		notifyConnectedChan:    make(chan struct{}),
+		initiateConnectionChan: make(chan struct{}, 1),
+		notifyFlushChan:        make(chan struct{}, 1),
+		apiClient:              apiClient,
+		messageBuffer:          newMessageBuffer(apiClient, logger),
+		state:                  ConnectionStateConnecting,
+	}
+	h.startConnection = func(context.Context, connectionEstablishData, ...connectOpt) {
+		h.notifyConnectedChan <- struct{}{}
+	}
+	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())
+	defer h.cancelWorkerCtx()
+
+	connectCtx, cancelConnect := context.WithCancel(context.Background())
+	defer cancelConnect()
+
+	_, err := h.Connect(connectCtx)
+	r.NoError(err)
+
+	// The retire notification can be consumed before ACKed work finishes.
+	// A later buffered reply must produce its own manager notification.
+	h.notifyFlushChan <- struct{}{}
+	r.Eventually(func() bool {
+		return len(h.notifyFlushChan) == 0
+	}, time.Second, time.Millisecond)
+
+	conn := newLifecycleTestConnection(nil)
+	r.NoError(conn.transition(connPhaseHandshaking, "test"))
+	r.NoError(conn.markActive("test"))
+	conn.retire("replacement connected")
+
+	err = h.writeReply(context.Background(), conn, &connectproto.SDKResponse{
+		RequestId: "late-request-id",
+	}, &connectproto.ConnectMessage{})
+	r.NoError(err)
+
+	select {
+	case <-flushSeen:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for late buffered response flush")
+	}
+
+	r.False(h.messageBuffer.hasMessages())
+	cancelConnect()
+	r.NoError(h.Close())
+}

--- a/connect/manager_state.go
+++ b/connect/manager_state.go
@@ -1,24 +1,7 @@
 package connect
 
 func (h *connectHandler) setState(state ConnectionState, reason string, attrs ...any) {
-	h.stateLock.Lock()
-	previous := h.state
-	if previous != state && !validConnectionStateTransition(previous, state) {
-		h.stateLock.Unlock()
-
-		// Manager state is user-visible, so invalid transitions are logged and
-		// ignored instead of silently reshaping what State() reports.
-		logAttrs := []any{
-			"from", previous,
-			"to", state,
-			"reason", reason,
-		}
-		logAttrs = append(logAttrs, attrs...)
-		h.logger.Warn("invalid worker connection state transition", logAttrs...)
-		return
-	}
-	h.state = state
-	h.stateLock.Unlock()
+	previous, valid := h.setStateLocked(state)
 
 	logAttrs := []any{
 		"from", previous,
@@ -26,7 +9,28 @@ func (h *connectHandler) setState(state ConnectionState, reason string, attrs ..
 		"reason", reason,
 	}
 	logAttrs = append(logAttrs, attrs...)
+
+	if !valid {
+		h.logger.Warn("invalid worker connection state transition", logAttrs...)
+		return
+	}
+
 	h.logger.Debug("worker connection state transition", logAttrs...)
+}
+
+func (h *connectHandler) setStateLocked(state ConnectionState) (ConnectionState, bool) {
+	h.stateLock.Lock()
+	defer h.stateLock.Unlock()
+
+	previous := h.state
+	if previous != state && !validConnectionStateTransition(previous, state) {
+		// Manager state is user-visible, so invalid transitions are logged and
+		// ignored instead of silently reshaping what State() reports.
+		return previous, false
+	}
+
+	h.state = state
+	return previous, true
 }
 
 // validConnectionStateTransition validates only the user-visible manager

--- a/connect/manager_state.go
+++ b/connect/manager_state.go
@@ -1,0 +1,64 @@
+package connect
+
+func (h *connectHandler) setState(state ConnectionState, reason string, attrs ...any) {
+	h.stateLock.Lock()
+	previous := h.state
+	if previous != state && !validConnectionStateTransition(previous, state) {
+		h.stateLock.Unlock()
+
+		// Manager state is user-visible, so invalid transitions are logged and
+		// ignored instead of silently reshaping what State() reports.
+		logAttrs := []any{
+			"from", previous,
+			"to", state,
+			"reason", reason,
+		}
+		logAttrs = append(logAttrs, attrs...)
+		h.logger.Warn("invalid worker connection state transition", logAttrs...)
+		return
+	}
+	h.state = state
+	h.stateLock.Unlock()
+
+	logAttrs := []any{
+		"from", previous,
+		"to", state,
+		"reason", reason,
+	}
+	logAttrs = append(logAttrs, attrs...)
+	h.logger.Debug("worker connection state transition", logAttrs...)
+}
+
+// validConnectionStateTransition validates only the user-visible manager
+// lifecycle. Websocket generation states such as Draining and Retired are
+// intentionally modeled separately in connection_lifecycle.go.
+func validConnectionStateTransition(from, to ConnectionState) bool {
+	switch from {
+	case ConnectionStateConnecting:
+		// Initial startup can establish a worker, be closed by the caller, or
+		// fail permanently before ever becoming active.
+		return to == ConnectionStateActive ||
+			to == ConnectionStateClosing ||
+			to == ConnectionStateClosed
+	case ConnectionStateActive:
+		// Active covers both the current websocket generation and gateway-drain
+		// overlap. Draining older generations must not change manager state.
+		return to == ConnectionStateReconnecting ||
+			to == ConnectionStateClosing ||
+			to == ConnectionStateClosed
+	case ConnectionStateReconnecting:
+		// Reconnect can succeed, keep retrying, be closed by the caller, or end
+		// permanently after max attempts or a non-reconnectable failure.
+		return to == ConnectionStateActive ||
+			to == ConnectionStateReconnecting ||
+			to == ConnectionStateClosing ||
+			to == ConnectionStateClosed
+	case ConnectionStateClosing:
+		// Close is terminal from the public manager point of view.
+		return to == ConnectionStateClosed
+	case ConnectionStateClosed:
+		return false
+	default:
+		return false
+	}
+}

--- a/connect/manager_state_test.go
+++ b/connect/manager_state_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -89,6 +90,88 @@ func TestManagerStateReconnectableFailureReturnsActiveAfterReconnect(t *testing.
 	r.Eventually(func() bool {
 		return h.State() == ConnectionStateActive
 	}, time.Second, time.Millisecond)
+
+	cancelConnect()
+	r.NoError(h.Close())
+}
+
+func TestManagerStateInitialRetryStaysConnectingUntilEstablished(t *testing.T) {
+	r := require.New(t)
+
+	var logOutput bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logOutput, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	events := make(chan string, 4)
+	releaseSecondConnect := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() {
+		close(releaseSecondConnect)
+	})
+
+	h := &connectHandler{
+		opts:                   Opts{IsDev: true},
+		logger:                 logger,
+		notifyConnectDoneChan:  make(chan connectReport),
+		notifyConnectedChan:    make(chan struct{}),
+		initiateConnectionChan: make(chan struct{}, 1),
+		notifyFlushChan:        make(chan struct{}, 1),
+		state:                  ConnectionStateConnecting,
+		messageBuffer:          newMessageBuffer(newWorkerApiClient("", nil), logger),
+		reconnectBackoff: func(int) time.Duration {
+			return 0
+		},
+	}
+	var startCalls atomic.Int32
+	h.startConnection = func(context.Context, connectionEstablishData, ...connectOpt) {
+		call := startCalls.Add(1)
+		events <- fmt.Sprintf("start-%d", call)
+
+		if call == 1 {
+			h.notifyConnectDoneChan <- connectReport{
+				reconnect: true,
+				err:       newReconnectErr(errors.New("startup read loop failed")),
+			}
+			return
+		}
+
+		<-releaseSecondConnect
+		h.notifyConnectedChan <- struct{}{}
+	}
+	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())
+	defer h.cancelWorkerCtx()
+
+	connectCtx, cancelConnect := context.WithCancel(context.Background())
+	defer cancelConnect()
+
+	connectErr := make(chan error, 1)
+	go func() {
+		_, err := h.Connect(connectCtx)
+		connectErr <- err
+	}()
+
+	r.Equal("start-1", <-events)
+	r.Equal("start-2", <-events)
+
+	// Before the first successful websocket, retrying is still startup.
+	// Public state should remain CONNECTING without logging an invalid
+	// CONNECTING -> RECONNECTING transition.
+	r.Equal(ConnectionStateConnecting, h.State())
+	r.NotContains(logOutput.String(), "invalid worker connection state transition")
+	r.NotContains(logOutput.String(), "to=RECONNECTING")
+
+	releaseOnce.Do(func() {
+		close(releaseSecondConnect)
+	})
+
+	select {
+	case err := <-connectErr:
+		r.NoError(err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial reconnect")
+	}
+	r.Equal(ConnectionStateActive, h.State())
 
 	cancelConnect()
 	r.NoError(h.Close())

--- a/connect/manager_state_test.go
+++ b/connect/manager_state_test.go
@@ -1,0 +1,162 @@
+package connect
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerStateInitialConnectionEntersActive(t *testing.T) {
+	r := require.New(t)
+
+	h := &connectHandler{
+		opts:                   Opts{IsDev: true},
+		logger:                 slog.New(slog.DiscardHandler),
+		notifyConnectDoneChan:  make(chan connectReport),
+		notifyConnectedChan:    make(chan struct{}),
+		initiateConnectionChan: make(chan struct{}, 1),
+		notifyFlushChan:        make(chan struct{}, 1),
+		state:                  ConnectionStateConnecting,
+		messageBuffer:          newMessageBuffer(newWorkerApiClient("", nil), slog.New(slog.DiscardHandler)),
+	}
+	h.startConnection = func(context.Context, connectionEstablishData, ...connectOpt) {
+		h.notifyConnectedChan <- struct{}{}
+	}
+	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())
+	defer h.cancelWorkerCtx()
+
+	connectCtx, cancelConnect := context.WithCancel(context.Background())
+	defer cancelConnect()
+
+	conn, err := h.Connect(connectCtx)
+	r.NoError(err)
+	r.Equal(h, conn)
+	r.Equal(ConnectionStateActive, h.State())
+
+	cancelConnect()
+	r.NoError(h.Close())
+}
+
+func TestManagerStateReconnectableFailureReturnsActiveAfterReconnect(t *testing.T) {
+	r := require.New(t)
+
+	events := make(chan string, 4)
+	h := &connectHandler{
+		opts:                   Opts{IsDev: true},
+		logger:                 slog.New(slog.DiscardHandler),
+		notifyConnectDoneChan:  make(chan connectReport),
+		notifyConnectedChan:    make(chan struct{}),
+		initiateConnectionChan: make(chan struct{}, 1),
+		notifyFlushChan:        make(chan struct{}, 1),
+		state:                  ConnectionStateConnecting,
+		messageBuffer:          newMessageBuffer(newWorkerApiClient("", nil), slog.New(slog.DiscardHandler)),
+		reconnectBackoff: func(int) time.Duration {
+			return 0
+		},
+	}
+	var startCalls atomic.Int32
+	h.startConnection = func(context.Context, connectionEstablishData, ...connectOpt) {
+		call := startCalls.Add(1)
+		events <- fmt.Sprintf("start-%d", call)
+		h.notifyConnectedChan <- struct{}{}
+	}
+	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())
+	defer h.cancelWorkerCtx()
+
+	connectCtx, cancelConnect := context.WithCancel(context.Background())
+	defer cancelConnect()
+
+	_, err := h.Connect(connectCtx)
+	r.NoError(err)
+	r.Equal("start-1", <-events)
+	r.Equal(ConnectionStateActive, h.State())
+
+	// A reconnectable generation failure should move through RECONNECTING and
+	// return to ACTIVE when the replacement generation connects.
+	h.notifyConnectDoneChan <- connectReport{
+		reconnect: true,
+		err:       newReconnectErr(errors.New("read loop failed")),
+	}
+
+	r.Equal("start-2", <-events)
+	r.Eventually(func() bool {
+		return h.State() == ConnectionStateActive
+	}, time.Second, time.Millisecond)
+
+	cancelConnect()
+	r.NoError(h.Close())
+}
+
+func TestManagerStateInvalidTransitionIsLoggedAndIgnored(t *testing.T) {
+	r := require.New(t)
+
+	var logOutput bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logOutput, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	h := &connectHandler{
+		logger: logger,
+		state:  ConnectionStateActive,
+	}
+
+	// ACTIVE -> CONNECTING would mix startup state back into an established
+	// manager lifecycle, so validation should leave the public state unchanged.
+	h.setState(ConnectionStateConnecting, "test invalid transition")
+
+	r.Equal(ConnectionStateActive, h.State())
+	r.Contains(logOutput.String(), "invalid worker connection state transition")
+	r.Contains(logOutput.String(), "from=ACTIVE")
+	r.Contains(logOutput.String(), "to=CONNECTING")
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	r := require.New(t)
+
+	releaseClose := make(chan struct{})
+	h := &connectHandler{
+		logger: slog.New(slog.DiscardHandler),
+		state:  ConnectionStateReconnecting,
+	}
+	h.workerCtx, h.cancelWorkerCtx = context.WithCancel(context.Background())
+	h.gracefulCloseEg.Go(func() error {
+		// Hold the first close open so the second Close call exercises the
+		// idempotent fast path while CLOSING is still observable.
+		<-releaseClose
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.Close()
+	}()
+
+	deadline := time.After(time.Second)
+	for h.State() != ConnectionStateClosing {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for CLOSING state")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	r.NoError(h.Close())
+
+	close(releaseClose)
+	select {
+	case err := <-done:
+		r.NoError(err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first Close")
+	}
+
+	r.Equal(ConnectionStateClosed, h.State())
+	r.NoError(h.Close())
+}

--- a/connect/request_lifecycle.go
+++ b/connect/request_lifecycle.go
@@ -68,6 +68,16 @@ func (h *connectHandler) writeReply(ctx context.Context, preparedConn *connectio
 
 func (h *connectHandler) bufferReply(resp *connectproto.SDKResponse) {
 	h.messageBuffer.append(resp)
+
+	// A reply can be buffered after the connection lifecycle notification was
+	// already consumed, so appending flushable work must also wake the manager.
+	if h.notifyFlushChan == nil {
+		return
+	}
+	select {
+	case h.notifyFlushChan <- struct{}{}:
+	default:
+	}
 }
 
 func canExtendRequestLease(preparedConn *connection) bool {

--- a/connect/request_lifecycle.go
+++ b/connect/request_lifecycle.go
@@ -1,0 +1,67 @@
+package connect
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/inngest/inngest/pkg/connect/wsproto"
+	"github.com/inngest/inngest/pkg/publicerr"
+	connectproto "github.com/inngest/inngest/proto/gen/connect/v1"
+)
+
+func (h *connectHandler) writeRequestAck(ctx context.Context, preparedConn *connection, ackPayload []byte, l *slog.Logger) error {
+	// ACK is the request ownership boundary. If this generation cannot ACK,
+	// do not invoke; the gateway/executor can retry or reroute the request.
+	if !preparedConn.canWriteRequestAck() {
+		return errConnectionRetired
+	}
+
+	if err := wsproto.Write(ctx, preparedConn.ws, &connectproto.ConnectMessage{
+		Kind:    connectproto.GatewayMessageType_WORKER_REQUEST_ACK,
+		Payload: ackPayload,
+	}); err != nil {
+		preparedConn.retire("request ack write failed", "err", err)
+		l.Error("error sending request ack", "error", err, "phase", preparedConn.phase())
+		return publicerr.Wrap(err, 400, "failed to ack worker request")
+	}
+
+	return nil
+}
+
+func (h *connectHandler) writeReply(ctx context.Context, preparedConn *connection, resp *connectproto.SDKResponse, responseMessage *connectproto.ConnectMessage) error {
+	if !preparedConn.canWriteReply() {
+		h.bufferReply(resp)
+		h.logger.Debug(
+			"buffering sdk response because connection phase does not allow reply write",
+			"request_id", resp.RequestId,
+			"phase", preparedConn.phase(),
+			"connection_id", preparedConn.connectionId,
+		)
+		return nil
+	}
+
+	if err := wsproto.Write(ctx, preparedConn.ws, responseMessage); err != nil {
+		// ACKed work has already completed. Preserve the existing policy:
+		// buffer the reply for API flush and do not retire on reply write
+		// failure.
+		h.bufferReply(resp)
+		h.logger.Debug(
+			"buffering sdk response after websocket write failure",
+			"err", err,
+			"request_id", resp.RequestId,
+			"phase", preparedConn.phase(),
+			"connection_id", preparedConn.connectionId,
+		)
+		return nil
+	}
+
+	return nil
+}
+
+func (h *connectHandler) bufferReply(resp *connectproto.SDKResponse) {
+	h.messageBuffer.append(resp)
+}
+
+func canExtendRequestLease(preparedConn *connection) bool {
+	return preparedConn.canWriteExtendLease()
+}

--- a/connect/request_lifecycle.go
+++ b/connect/request_lifecycle.go
@@ -2,6 +2,7 @@ package connect
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/inngest/inngest/pkg/connect/wsproto"
@@ -14,6 +15,13 @@ func (h *connectHandler) writeRequestAck(ctx context.Context, preparedConn *conn
 	// do not invoke; the gateway/executor can retry or reroute the request.
 	if !preparedConn.canWriteRequestAck() {
 		return errConnectionRetired
+	}
+
+	if err := ctx.Err(); err != nil {
+		writeErr := fmt.Errorf("could not write message to websocket: %w", err)
+		preparedConn.retire("request ack write failed", "err", writeErr)
+		l.Error("error sending request ack", "error", writeErr, "phase", preparedConn.phase())
+		return publicerr.Wrap(writeErr, 400, "failed to ack worker request")
 	}
 
 	if err := wsproto.Write(ctx, preparedConn.ws, &connectproto.ConnectMessage{

--- a/connect/request_lifecycle_test.go
+++ b/connect/request_lifecycle_test.go
@@ -1,0 +1,92 @@
+package connect
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	connectproto "github.com/inngest/inngest/proto/gen/connect/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteRequestAckSkipsWhenPhaseDisallowsAck(t *testing.T) {
+	r := require.New(t)
+
+	h := &connectHandler{}
+	conn := newLifecycleTestConnection(nil)
+	r.NoError(conn.transition(connPhaseHandshaking, "test"))
+	r.NoError(conn.markActive("test"))
+	r.NoError(conn.beginDrain("replacement connected"))
+
+	err := h.writeRequestAck(context.Background(), conn, []byte("{}"), slog.New(slog.DiscardHandler))
+
+	// Draining generations may finish already-ACKed work, but they must not
+	// take ownership of new requests by sending a fresh ACK.
+	r.ErrorIs(err, errConnectionRetired)
+	r.Equal(connPhaseDraining, conn.phase())
+}
+
+func TestWriteRequestAckCanceledContextRetiresBeforeInvoke(t *testing.T) {
+	r := require.New(t)
+	var logOutput bytes.Buffer
+
+	logger := slog.New(slog.NewTextHandler(&logOutput, nil))
+	h := &connectHandler{}
+	conn := newLifecycleTestConnection(nil)
+	r.NoError(conn.transition(connPhaseHandshaking, "test"))
+	r.NoError(conn.markActive("test"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := h.writeRequestAck(ctx, conn, []byte("{}"), logger)
+
+	// A hard ACK write failure means the request never became this worker's
+	// responsibility. Retiring the generation also suppresses later stale
+	// writes from the same websocket.
+	r.Error(err)
+	r.Contains(err.Error(), "could not write message to websocket")
+	r.True(conn.isRetired())
+	r.Contains(logOutput.String(), "could not write message to websocket")
+}
+
+func TestWriteReplyBuffersWhenPhaseDisallowsReply(t *testing.T) {
+	r := require.New(t)
+
+	logger := slog.New(slog.DiscardHandler)
+	h := &connectHandler{
+		logger:        logger,
+		messageBuffer: newMessageBuffer(newWorkerApiClient("", nil), logger),
+	}
+	conn := newLifecycleTestConnection(nil)
+	r.NoError(conn.transition(connPhaseHandshaking, "test"))
+	r.NoError(conn.markActive("test"))
+	conn.retire("replacement connected")
+
+	resp := &connectproto.SDKResponse{RequestId: "request-id"}
+	err := h.writeReply(context.Background(), conn, resp, &connectproto.ConnectMessage{})
+
+	// Replies happen after request ownership was established. If this
+	// generation can no longer write, keep the result for API flush instead of
+	// dropping completed work.
+	r.NoError(err)
+	h.messageBuffer.lock.Lock()
+	defer h.messageBuffer.lock.Unlock()
+	r.Contains(h.messageBuffer.buffered, "request-id")
+}
+
+func TestCanExtendRequestLeaseByPhase(t *testing.T) {
+	r := require.New(t)
+
+	conn := newLifecycleTestConnection(nil)
+	r.NoError(conn.transition(connPhaseHandshaking, "test"))
+	r.NoError(conn.markActive("test"))
+	r.True(canExtendRequestLease(conn))
+
+	conn.retire("replacement connected")
+
+	// Lease extension is only useful while this generation is still allowed to
+	// speak for in-flight work.
+	r.False(canExtendRequestLease(conn))
+}

--- a/connect/request_lifecycle_test.go
+++ b/connect/request_lifecycle_test.go
@@ -47,7 +47,7 @@ func TestWriteRequestAckCanceledContextRetiresBeforeInvoke(t *testing.T) {
 	// writes from the same websocket.
 	r.Error(err)
 	r.Contains(err.Error(), "could not write message to websocket")
-	r.True(conn.isRetired())
+	r.Equal(connPhaseRetired, conn.phase())
 	r.Contains(logOutput.String(), "could not write message to websocket")
 }
 

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -844,30 +844,43 @@ Purpose: remove redundant lifecycle mechanisms and document the final contract.
 
 *** Implementation checklist
 
-- [ ] Remove obsolete direct retired checks after all writes use phase helpers.
-- [ ] Remove redundant close calls if lifecycle close helpers make them
+- [X] Remove obsolete direct retired checks after all writes use phase helpers.
+- [X] Remove redundant close calls if lifecycle close helpers make them
   unnecessary.
-- [ ] Keep fallback close safeguards where they are still useful.
-- [ ] Update code comments around gateway drain, unexpected close, and graceful
+- [X] Keep fallback close safeguards where they are still useful.
+- [X] Update code comments around gateway drain, unexpected close, and graceful
   shutdown.
-- [ ] Update this plan with decisions made during implementation.
+- [X] Update this plan with decisions made during implementation.
+
+Decision notes:
+
+- The old =isRetired()= shortcut was removed. Tests now assert concrete
+  generation phases so they stay aligned with the write policy table.
+- Explicit close calls in gateway drain and graceful shutdown remain because
+  they provide protocol-specific close reasons at the point the lifecycle moves
+  to =Closed=.
+- The deferred =closeNow("handle connection ended")= remains as an idempotent
+  fallback for unhandled exits that do not reach a specific drain, shutdown, or
+  read-error close path.
+- No new phase 6 behavior bug was found. The phase 5 canceled-ACK regression is
+  covered by =TestWriteRequestAckCanceledContextRetiresBeforeInvoke=.
 
 *** Test checklist
 
-- [ ] Full Connect package tests pass.
-- [ ] Add regression tests for any bug found during phases 1-5.
+- [X] Full Connect package tests pass.
+- [X] Add regression tests for any bug found during phases 1-5.
 
 *** Validation checklist
 
-- [ ] =go test ./connect -count=1=
-- [ ] Optional: run broader package test if touched imports or shared helpers
-  expand beyond =connect=.
+- [X] =go test ./connect -count=1=
+- [X] Optional broader package test was not required because phase 6 touched
+  only =connect= package lifecycle code and tests.
 
 *** Exit criteria
 
-- [ ] Lifecycle rules are discoverable from code and this plan.
-- [ ] State transitions own their side effects.
-- [ ] Tests cover each state boundary that affects writes, close behavior, or
+- [X] Lifecycle rules are discoverable from code and this plan.
+- [X] State transitions own their side effects.
+- [X] Tests cover each state boundary that affects writes, close behavior, or
   request execution.
 
 * Success Criteria

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -1,7 +1,7 @@
 #+TITLE: Connect Lifecycle Controller
 #+AUTHOR: Darwin D. Wu
 #+DATE: 2026-05-08
-#+STATUS: Active
+#+STATUS: Done
 #+STARTUP: showall
 
 * Overview

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -802,41 +802,41 @@ cancellation semantics.
 
 *** Implementation checklist
 
-- [ ] Add small request helper functions or a request context wrapper if needed.
-- [ ] Encode request boundaries:
-  - [ ] before ACK: require generation phase that allows ACK;
-  - [ ] ACK write must succeed before invocation starts;
-  - [ ] hard ACK write failure retires the generation before returning;
-  - [ ] after ACK: invocation continues independent of generation phase;
-  - [ ] before reply write: require generation phase that allows reply;
-  - [ ] otherwise buffer reply;
-  - [ ] before lease extend: require generation phase that allows lease extend.
-- [ ] Keep =InvokeFunction(context.Background(), ...)= behavior unless a
+- [X] Add small request helper functions or a request context wrapper if needed.
+- [X] Encode request boundaries:
+  - [X] before ACK: require generation phase that allows ACK;
+  - [X] ACK write must succeed before invocation starts;
+  - [X] hard ACK write failure retires the generation before returning;
+  - [X] after ACK: invocation continues independent of generation phase;
+  - [X] before reply write: require generation phase that allows reply;
+  - [X] otherwise buffer reply;
+  - [X] before lease extend: require generation phase that allows lease extend.
+- [X] Keep =InvokeFunction(context.Background(), ...)= behavior unless a
   separate decision changes cancellation semantics.
-- [ ] Ensure pending ACK cleanup remains independent of generation lifecycle.
-- [ ] Make request logs include connection ID and generation phase where useful.
+- [X] Ensure pending ACK cleanup remains independent of generation lifecycle.
+- [X] Make request logs include connection ID and generation phase where useful.
 
 *** Test checklist
 
-- [ ] Queued request on =Retired= does not ACK and does not invoke.
-- [ ] ACK write failure while =Active= does not invoke.
-- [ ] ACK write failure while =Active= retires the generation and suppresses
+- [X] Queued request on =Retired= does not ACK and does not invoke.
+- [X] ACK write failure while =Active= does not invoke.
+- [X] ACK write failure while =Active= retires the generation and suppresses
   repeated stale ACK attempts from later queued work.
-- [ ] ACKed in-flight request on =Retired= completes and buffers reply.
-- [ ] Reply ACK clears =pendingAck=.
-- [ ] Lease extension exits when generation becomes =Retired=.
-- [ ] Request tests assert behavior by phase, not by websocket race timing.
+- [X] ACKed in-flight request on =Retired= completes and buffers reply.
+- [X] Reply ACK clears =pendingAck=.
+- [X] Lease extension exits when generation becomes =Retired=.
+- [X] Request tests assert behavior by phase, not by websocket race timing.
 
 *** Validation checklist
 
-- [ ] =go test ./connect -count=1=
-- [ ] No SYS-856-style stale websocket write logs are expected from request
+- [X] =go test ./connect -count=1=
+- [X] No SYS-856-style stale websocket write logs are expected from request
   paths after =Retired=.
 
 *** Exit criteria
 
-- [ ] Request behavior is explicit for each relevant generation phase.
-- [ ] In-flight ACKed function execution still completes across reconnect.
+- [X] Request behavior is explicit for each relevant generation phase.
+- [X] In-flight ACKed function execution still completes across reconnect.
 
 ** Phase 6: Cleanup and documentation
 

--- a/docs/plans/000-connect-lifecycle-controller.org
+++ b/docs/plans/000-connect-lifecycle-controller.org
@@ -754,46 +754,46 @@ websocket generation state.
 
 *** Implementation checklist
 
-- [ ] Add manager transition validation around =setState=.
-- [ ] Keep manager states coarse:
-  - [ ] =CONNECTING=
-  - [ ] =ACTIVE=
-  - [ ] =RECONNECTING=
-  - [ ] =CLOSING=
-  - [ ] =CLOSED=
-- [ ] Decide what to do with =PAUSED=:
-  - [ ] define exactly when it is entered; or
-  - [ ] remove it if it remains unused.
-- [ ] Make invalid manager transitions visible in logs.
-- [ ] Ensure reconnect overlap does not require changing manager state away
+- [X] Add manager transition validation around =setState=.
+- [X] Keep manager states coarse:
+  - [X] =CONNECTING=
+  - [X] =ACTIVE=
+  - [X] =RECONNECTING=
+  - [X] =CLOSING=
+  - [X] =CLOSED=
+- [X] Decide what to do with =PAUSED=:
+  - [X] retain it for source compatibility;
+  - [X] document that the manager lifecycle no longer enters it.
+- [X] Make invalid manager transitions visible in logs.
+- [X] Ensure reconnect overlap does not require changing manager state away
   from =ACTIVE= while old generation drains.
-- [ ] Add a serialized manager-owned flush path for lifecycle flush
+- [X] Add a serialized manager-owned flush path for lifecycle flush
   notifications:
-  - [ ] notification is non-blocking;
-  - [ ] repeated notifications are coalesced or serialized;
-  - [ ] flush uses current manager auth state;
-  - [ ] reconnect and close flushes remain safety points.
+  - [X] notification is non-blocking;
+  - [X] repeated notifications are coalesced or serialized;
+  - [X] flush uses current manager auth state;
+  - [X] reconnect and close flushes remain safety points.
 
 *** Test checklist
 
-- [ ] Initial connection moves =CONNECTING -> ACTIVE=.
-- [ ] Reconnectable failure moves =ACTIVE -> RECONNECTING -> ACTIVE=.
-- [ ] Non-reconnectable failure moves to =CLOSED=.
-- [ ] =Close= moves =ACTIVE/RECONNECTING -> CLOSING -> CLOSED=.
-- [ ] Double =Close= is idempotent.
-- [ ] Manager flush notification triggers one serialized API flush.
-- [ ] Repeated flush notifications do not start concurrent flushes.
-- [ ] Invalid transitions are rejected or logged clearly.
+- [X] Initial connection moves =CONNECTING -> ACTIVE=.
+- [X] Reconnectable failure moves =ACTIVE -> RECONNECTING -> ACTIVE=.
+- [X] Non-reconnectable failure moves to =CLOSED=.
+- [X] =Close= moves =ACTIVE/RECONNECTING -> CLOSING -> CLOSED=.
+- [X] Double =Close= is idempotent.
+- [X] Manager flush notification triggers one serialized API flush.
+- [X] Repeated flush notifications do not start concurrent flushes.
+- [X] Invalid transitions are rejected or logged clearly.
 
 *** Validation checklist
 
-- [ ] =go test ./connect -count=1=
-- [ ] Existing public =State()= behavior remains compatible.
+- [X] =go test ./connect -count=1=
+- [X] Existing public =State()= behavior remains compatible.
 
 *** Exit criteria
 
-- [ ] Manager state documents user-visible lifecycle only.
-- [ ] Websocket generation state owns write and transport lifecycle.
+- [X] Manager state documents user-visible lifecycle only.
+- [X] Websocket generation state owns write and transport lifecycle.
 
 ** Phase 5: Tighten request lifecycle boundaries
 


### PR DESCRIPTION
## Summary
- split Connect websocket generation lifecycle from user-visible manager state
- centralize write permissions for ACKs, replies, heartbeats, pause, and lease extension by generation phase
- preserve gateway drain and graceful shutdown behavior while retiring stale generations before stale writes
- serialize lifecycle-triggered buffer flushes through the manager and cover late retired replies
- tighten startup retry state transitions so retries remain CONNECTING until a connection is active
- document completed lifecycle plan decisions through phase 6

## Tests
- go test ./connect -count=1
