### PR TITLE
feat(connect): configure heartbeat tolerance

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -32,10 +32,15 @@ type ConnectOpts struct {
 	MaxWorkerConcurrency *int64
 
 	// MessageReadLimit sets the max number of bytes to read for a single WebSocket message.
-	// By default (nil or 0), the connection has a message read limit of 32768 bytes (32KB).
+	// By default (nil or 0), the connection has a message read limit of 10MB.
 	// Set to -1 to disable the limit.
 	// Set to any positive value to use a custom limit.
 	MessageReadLimit *int64
+
+	// MissedGatewayHeartbeatTolerance is the number of gateway heartbeat periods
+	// that may pass without a gateway heartbeat before reconnecting.
+	// Defaults to 3. Negative values use the default.
+	MissedGatewayHeartbeatTolerance *int
 }
 
 func Connect(ctx context.Context, opts ConnectOpts) (connect.WorkerConnection, error) {
@@ -100,20 +105,21 @@ func Connect(ctx context.Context, opts ConnectOpts) (connect.WorkerConnection, e
 	}
 
 	return connect.Connect(ctx, connect.Opts{
-		Apps:                     apps,
-		Env:                      defaultClient.Env,
-		Capabilities:             capabilities,
-		HashedSigningKey:         hashedKey,
-		HashedSigningKeyFallback: hashedFallbackKey,
-		MaxWorkerConcurrency:     opts.MaxWorkerConcurrency,
-		MessageReadLimit:         opts.MessageReadLimit,
-		APIBaseURL:               defaultClient.h.GetAPIBaseURL(),
-		IsDev:                    defaultClient.h.isDev(),
-		InstanceID:               opts.InstanceID,
-		Platform:                 Ptr(platform()),
-		SDKVersion:               SDKVersion,
-		SDKLanguage:              SDKLanguage,
-		RewriteGatewayEndpoint:   opts.RewriteGatewayEndpoint,
+		Apps:                            apps,
+		Env:                             defaultClient.Env,
+		Capabilities:                    capabilities,
+		HashedSigningKey:                hashedKey,
+		HashedSigningKeyFallback:        hashedFallbackKey,
+		MaxWorkerConcurrency:            opts.MaxWorkerConcurrency,
+		MessageReadLimit:                opts.MessageReadLimit,
+		MissedGatewayHeartbeatTolerance: opts.MissedGatewayHeartbeatTolerance,
+		APIBaseURL:                      defaultClient.h.GetAPIBaseURL(),
+		IsDev:                           defaultClient.h.isDev(),
+		InstanceID:                      opts.InstanceID,
+		Platform:                        Ptr(platform()),
+		SDKVersion:                      SDKVersion,
+		SDKLanguage:                     SDKLanguage,
+		RewriteGatewayEndpoint:          opts.RewriteGatewayEndpoint,
 	}, invokers, defaultClient.Logger)
 }
 

--- a/connect/connection.go
+++ b/connect/connection.go
@@ -17,11 +17,29 @@ import (
 	"time"
 )
 
+// defaultMissedGatewayHeartbeatTolerance allows transient gateway heartbeat
+// gaps without keeping an unhealthy websocket open indefinitely.
+const defaultMissedGatewayHeartbeatTolerance = 3
+
 var (
 	defaultWSReadLimit int64 = 10 * 1024 * 1024 // 10MB
 
 	gatewayDrainReplacementTimeout = 10 * time.Second
 )
+
+func (h *connectHandler) missedGatewayHeartbeatTolerance() int {
+	if h.opts.MissedGatewayHeartbeatTolerance == nil || *h.opts.MissedGatewayHeartbeatTolerance < 0 {
+		return defaultMissedGatewayHeartbeatTolerance
+	}
+
+	return *h.opts.MissedGatewayHeartbeatTolerance
+}
+
+func gatewayHeartbeatTimeout(heartbeatInterval time.Duration, missedTolerance int) time.Duration {
+	// The first interval covers the next expected gateway heartbeat. Each
+	// additional interval is one tolerated miss before disconnecting.
+	return time.Duration(missedTolerance+1) * heartbeatInterval
+}
 
 type connectReport struct {
 	reconnect bool
@@ -262,14 +280,17 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 
 	heartbeatReceived := make(chan struct{}, 1)
 	go func() {
-		// Wait until initial heartbeat was sent out
+		// Start checking only after the worker has had a chance to send its
+		// first heartbeat. The gateway heartbeat deadline is then reset every
+		// time a gateway heartbeat is read below.
 		select {
 		case <-backgroundCtx.Done():
 			return
 		case <-time.After(preparedConn.heartbeatInterval):
 		}
 
-		heartbeatTimeout := 2 * preparedConn.heartbeatInterval
+		missedTolerance := h.missedGatewayHeartbeatTolerance()
+		heartbeatTimeout := gatewayHeartbeatTimeout(preparedConn.heartbeatInterval, missedTolerance)
 		heartbeatReplyTimer := time.NewTimer(heartbeatTimeout)
 		defer heartbeatReplyTimer.Stop()
 		for {
@@ -286,7 +307,7 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 				heartbeatReplyTimer.Reset(heartbeatTimeout)
 			case <-heartbeatReplyTimer.C:
 				// No heartbeat received in time!
-				l.Error("did not receive gateway heartbeat in time", "heartbeat_interval", preparedConn.heartbeatInterval.String(), "heartbeat_timeout", heartbeatTimeout.String())
+				l.Error("did not receive gateway heartbeat in time", "heartbeat_interval", preparedConn.heartbeatInterval.String(), "heartbeat_timeout", heartbeatTimeout.String(), "missed_heartbeat_tolerance", missedTolerance)
 				cancelReaderLifetimeContext()
 				return
 			}

--- a/connect/connection_write_test.go
+++ b/connect/connection_write_test.go
@@ -53,6 +53,60 @@ func TestConnectionWritePolicyByPhase(t *testing.T) {
 	}
 }
 
+func TestGatewayHeartbeatTimeoutUsesMissedHeartbeatTolerance(t *testing.T) {
+	r := require.New(t)
+	interval := 250 * time.Millisecond
+
+	r.Equal(3, defaultMissedGatewayHeartbeatTolerance)
+	r.Equal(4*interval, gatewayHeartbeatTimeout(interval, defaultMissedGatewayHeartbeatTolerance))
+	r.Equal(interval, gatewayHeartbeatTimeout(interval, 0))
+	r.Equal(6*interval, gatewayHeartbeatTimeout(interval, 5))
+}
+
+func TestMissedGatewayHeartbeatTolerance(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    *int
+		expected int
+	}{
+		{
+			name:     "default",
+			expected: defaultMissedGatewayHeartbeatTolerance,
+		},
+		{
+			name:     "zero",
+			value:    intPtr(0),
+			expected: 0,
+		},
+		{
+			name:     "custom",
+			value:    intPtr(5),
+			expected: 5,
+		},
+		{
+			name:     "negative uses default",
+			value:    intPtr(-1),
+			expected: defaultMissedGatewayHeartbeatTolerance,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &connectHandler{
+				opts: Opts{
+					MissedGatewayHeartbeatTolerance: tt.value,
+				},
+			}
+
+			require.Equal(t, tt.expected, h.missedGatewayHeartbeatTolerance())
+		})
+	}
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
 func TestHandleInvokeMessageSkipsAckWhenPhaseDisallowsAck(t *testing.T) {
 	r := require.New(t)
 	var logOutput bytes.Buffer

--- a/connect/handler.go
+++ b/connect/handler.go
@@ -126,6 +126,11 @@ type Opts struct {
 	// Set to any positive value to use a custom limit.
 	MessageReadLimit *int64
 
+	// MissedGatewayHeartbeatTolerance is the number of gateway heartbeat periods
+	// that may pass without a gateway heartbeat before reconnecting.
+	// Defaults to 3. Negative values use the default.
+	MissedGatewayHeartbeatTolerance *int
+
 	APIBaseURL string
 	IsDev      bool
 


### PR DESCRIPTION
## Summary

- Make connect gateway heartbeat tolerance configurable via ConnectOpts
- Keep the default tolerance at 3 missed gateway heartbeat periods before reconnecting
- Allow zero tolerance, while negative values fall back to the default
- Correct the public MessageReadLimit comment to match the 10MB default

## Tests

- go test ./connect
- go test .