### PR TITLE
feat: add throttle scope config support

### DIFF
--- a/expose_internal.go
+++ b/expose_internal.go
@@ -32,6 +32,9 @@ type (
 	// concurrency limits.
 	ConfigThrottle = fn.Throttle
 
+	// ConfigThrottleScope controls how broadly throttle capacity is shared.
+	ConfigThrottleScope = fn.ThrottleScope
+
 	// ConfigRateLimit rate limits a function to a maximum number of runs over a given period.
 	// Any runs over the limit are ignored and are NOT enqueued for the future.
 	ConfigRateLimit = fn.RateLimit
@@ -95,6 +98,15 @@ type (
 	// - Ensuring that critical work is executed before other work in the queue.
 	// - Prioritizing certain jobs during onboarding to give the user a better first-run experience.
 	ConfigPriority = fn.Priority
+)
+
+const (
+	// ThrottleScopeFn limits throttle capacity to the current function.
+	ThrottleScopeFn = fn.ThrottleScopeFn
+	// ThrottleScopeEnv shares throttle capacity across functions in the current environment.
+	ThrottleScopeEnv = fn.ThrottleScopeEnv
+	// ThrottleScopeAccount shares throttle capacity across functions in the current account.
+	ThrottleScopeAccount = fn.ThrottleScopeAccount
 )
 
 type (

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -189,6 +189,18 @@ type StepConcurrency struct {
 // Concurrency is an alias for StepConcurrency for backward compatibility.
 type Concurrency = StepConcurrency
 
+// ThrottleScope controls how broadly a throttle key is shared.
+type ThrottleScope string
+
+const (
+	// ThrottleScopeFn limits throttle capacity to the current function.
+	ThrottleScopeFn ThrottleScope = "fn"
+	// ThrottleScopeEnv shares throttle capacity across functions in the current environment.
+	ThrottleScopeEnv ThrottleScope = "env"
+	// ThrottleScopeAccount shares throttle capacity across functions in the current account.
+	ThrottleScopeAccount ThrottleScope = "account"
+)
+
 // Cancel represents a cancellation signal for a function.  When specified, this
 // will set up pauses which automatically cancel the function based off of matching
 // events and expressions.
@@ -273,6 +285,9 @@ type Throttle struct {
 	// ID in an event you can use the following key: "event.user.id".  This ensures
 	// that we throttle functions for each user independently.
 	Key *string `json:"key,omitempty"`
+	// Scope controls whether the throttle applies to the function, environment, or account.
+	// Defaults to the current function when unset.
+	Scope ThrottleScope `json:"scope,omitempty"`
 }
 
 // MarshalJSON marshals Throttle to the expected JSON format.  Note that time.Duration

--- a/internal/fn/fn_test.go
+++ b/internal/fn/fn_test.go
@@ -40,6 +40,32 @@ func TestTimeoutMarhsal(t *testing.T) {
 	})
 }
 
+func TestThrottleMarshalJSON(t *testing.T) {
+	t.Run("without scope", func(t *testing.T) {
+		v := Throttle{
+			Limit:  10,
+			Period: time.Minute,
+			Burst:  1,
+		}
+		byt, err := v.MarshalJSON()
+		require.NoError(t, err)
+		require.JSONEq(t, `{"limit":10,"period":"1m","burst":1}`, string(byt))
+	})
+
+	t.Run("with account scope", func(t *testing.T) {
+		v := Throttle{
+			Limit:  10,
+			Period: time.Minute,
+			Burst:  1,
+			Key:    ptr("event.data.provider"),
+			Scope:  ThrottleScopeAccount,
+		}
+		byt, err := v.MarshalJSON()
+		require.NoError(t, err)
+		require.JSONEq(t, `{"limit":10,"period":"1m","burst":1,"key":"event.data.provider","scope":"account"}`, string(byt))
+	})
+}
+
 func TestTriggerMarshalJSON(t *testing.T) {
 	t.Run("event trigger with nil CronTrigger", func(t *testing.T) {
 		tr := Trigger{EventTrigger: &EventTrigger{Event: "test/event"}}


### PR DESCRIPTION
Summary
- Adds Go SDK support for configuring shared throttle scopes when registering functions.

Changes
- Adds `Throttle.Scope` to function throttle configuration.
- Exposes `ConfigThrottleScope` and `ThrottleScopeFn`/`ThrottleScopeEnv`/`ThrottleScopeAccount` constants from the root package.
- Keeps existing throttle payloads unchanged when `Scope` is unset.
- Adds serialization coverage for scoped and unscoped throttle configs.

Tests
- `go test ./internal/fn -run 'TestThrottleMarshalJSON|TestTimeoutMarhsal|TestTriggerMarshalJSON' -count=1`
- `go test ./... -run 'TestThrottleMarshalJSON|TestTimeoutMarhsal|TestTriggerMarshalJSON' -count=1`
- `make lint`
- `make utest`

Related Issues
- Server/runtime PR: https://github.com/inngest/inngest/pull/4407
- TypeScript SDK PR: https://github.com/inngest/inngest-js/pull/1576
- Python SDK PR: https://github.com/inngest/inngest-py/pull/367
- Feature request: https://github.com/inngest/inngest/issues/3701
