### PR TITLE
chore: change 0-major semver logic

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -94,3 +94,10 @@ topo_order_commits = true
 sort_commits = "oldest"
 # Process submodules commits
 recurse_submodules = false
+
+# Keep 0.x releases aligned with npm-style pre-1.0 semver: features bump patch,
+# while breaking changes bump minor. Remove this section once the SDK reaches
+# v1.0.0 so git-cliff's default semver bump behavior applies.
+[bump]
+breaking_always_bump_major = false
+features_always_bump_minor = false


### PR DESCRIPTION
# Summary

Change auto-versioning logic to:
- Bump minor version on breaking change (e.g. `0.15.0` -> `0.16.0`)
- Bump patch version on feature change (e.g. `0.15.0` -> `0.15.1`)

# Context

This aligns with our versioning strategy when our release process was more manual. We did this because we wanted users to know when a release contains a breaking change. If both breaking changes and features bump the minor version, then the version doesn't communicate the presence of a breaking change.

This "shift right" 0-major strategy is not in the semver spec. However, it's adopted by other package managers (e.g. npm).