### PR TITLE
feat!: always enable authenticated syncs

### DIFF
--- a/client.go
+++ b/client.go
@@ -108,10 +108,6 @@ type ClientOpts struct {
 	// differs from true streaming in that we don't support server-sent events.
 	UseStreaming bool
 
-	// AllowInBandSync allows in-band syncs to occur. If nil, in-band syncs are
-	// disallowed.
-	AllowInBandSync *bool
-
 	// Dev is whether to use the Dev Server.
 	Dev *bool
 
@@ -171,7 +167,6 @@ func clientOptsToHandlerOpts(opts ClientOpts) handlerOpts {
 		MaxBodySize:        opts.MaxBodySize,
 		URL:                opts.URL,
 		UseStreaming:       opts.UseStreaming,
-		AllowInBandSync:    opts.AllowInBandSync,
 		Dev:                opts.Dev,
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"reflect"
 	"runtime/debug"
-	"strings"
 	"sync"
 	"time"
 
@@ -50,10 +49,6 @@ var (
 		TrustProbe: types.TrustProbeV1,
 		Connect:    types.ConnectV1,
 	}
-)
-
-const (
-	envKeyAllowInBandSync = "INNGEST_ALLOW_IN_BAND_SYNC"
 )
 
 type handlerOpts struct {
@@ -110,10 +105,6 @@ type handlerOpts struct {
 	// UseStreaming enables streaming - continued writes to the HTTP writer.  This
 	// differs from true streaming in that we don't support server-sent events.
 	UseStreaming bool
-
-	// AllowInBandSync allows in-band syncs to occur. If nil, in-band syncs are
-	// disallowed.
-	AllowInBandSync *bool
 
 	Dev *bool
 }
@@ -223,19 +214,6 @@ func (h handlerOpts) GetRegisterURL() string {
 		return "https://www.inngest.com/fn/register"
 	}
 	return *h.RegisterURL
-}
-
-func (h handlerOpts) IsInBandSyncAllowed() bool {
-	if h.AllowInBandSync != nil {
-		return *h.AllowInBandSync
-	}
-
-	// TODO: Default to true once in-band syncing is stable
-	if isTrue(os.Getenv(envKeyAllowInBandSync)) {
-		return true
-	}
-
-	return false
 }
 
 func (h handlerOpts) isDev() bool {
@@ -415,7 +393,9 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *handler) register(w http.ResponseWriter, r *http.Request) error {
 	var syncKind string
 	var err error
-	if r.Header.Get(HeaderKeySyncKind) == SyncKindInBand && h.IsInBandSyncAllowed() {
+	// Signed registration requests carry the in-band sync payload. Validate the
+	// signature inside inBandSync after reading the body.
+	if r.Header.Get(HeaderKeySignature) != "" {
 		syncKind = SyncKindInBand
 		err = h.inBandSync(w, r)
 	} else {
@@ -466,16 +446,14 @@ func (h *handler) inBandSync(
 		_ = r.Body.Close()
 	}()
 
-	var sig string
-	if !h.isDev() {
-		if sig = r.Header.Get(HeaderKeySignature); sig == "" {
-			return publicerr.Error{
-				Err: syscode.Error{
-					Code:    syscode.CodeHTTPMissingHeader,
-					Message: fmt.Sprintf("missing %s header", HeaderKeySignature),
-				},
-				Status: 401,
-			}
+	sig := r.Header.Get(HeaderKeySignature)
+	if sig == "" {
+		return publicerr.Error{
+			Err: syscode.Error{
+				Code:    syscode.CodeHTTPMissingHeader,
+				Message: fmt.Sprintf("missing %s header", HeaderKeySignature),
+			},
+			Status: 401,
 		}
 	}
 
@@ -497,7 +475,7 @@ func (h *handler) inBandSync(
 		h.GetSigningKey(),
 		h.GetSigningKeyFallback(),
 		reqByt,
-		h.isDev(),
+		false,
 	)
 	if err != nil {
 		return publicerr.Error{
@@ -1497,12 +1475,4 @@ func updateInput(
 	}
 
 	return nil
-}
-
-func isTrue(val string) bool {
-	val = strings.ToLower(val)
-	if val == "true" || val == "1" {
-		return true
-	}
-	return false
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -922,8 +922,7 @@ func TestInBandSync(t *testing.T) {
 	)
 	r.NoError(err)
 	h := newHandler(c, handlerOpts{
-		AllowInBandSync: toPtr(true),
-		Env:             toPtr("my-env"),
+		Env: toPtr("my-env"),
 	})
 	h.Register(fn)
 	server := httptest.NewServer(h)
@@ -934,8 +933,7 @@ func TestInBandSync(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		// SDK responds with sync data when receiving a valid in-band sync
-		// request
+		// SDK responds with sync data when receiving a signed sync request.
 
 		r := require.New(t)
 		ctx := context.Background()
@@ -948,7 +946,6 @@ func TestInBandSync(t *testing.T) {
 		)
 		r.NoError(err)
 		req.Header.Set("x-inngest-signature", sig)
-		req.Header.Set("x-inngest-sync-kind", "in_band")
 		resp, err := http.DefaultClient.Do(req)
 		r.NoError(err)
 		r.Equal(http.StatusOK, resp.StatusCode)
@@ -1027,7 +1024,6 @@ func TestInBandSync(t *testing.T) {
 		)
 		r.NoError(err)
 		req.Header.Set("x-inngest-signature", sig)
-		req.Header.Set("x-inngest-sync-kind", "in_band")
 		resp, err := http.DefaultClient.Do(req)
 		r.NoError(err)
 		r.Equal(http.StatusUnauthorized, resp.StatusCode)
@@ -1043,42 +1039,15 @@ func TestInBandSync(t *testing.T) {
 		}, respBody)
 	})
 
-	t.Run("missing signature", func(t *testing.T) {
-		// SDK responds with an error when receiving an in-band sync request
-		// with a missing signature
+	t.Run("unsigned request", func(t *testing.T) {
+		// SDK attempts an out-of-band sync when the request is unsigned.
 
 		r := require.New(t)
-
-		req, err := http.NewRequest(
-			http.MethodPut,
-			server.URL,
-			bytes.NewReader(reqBodyByt),
-		)
-		r.NoError(err)
-		req.Header.Set("x-inngest-sync-kind", "in_band")
-		resp, err := http.DefaultClient.Do(req)
-		r.NoError(err)
-		r.Equal(http.StatusUnauthorized, resp.StatusCode)
-		r.Equal(resp.Header.Get("x-inngest-sync-kind"), "")
-
-		var respBody map[string]any
-		err = json.NewDecoder(resp.Body).Decode(&respBody)
-		r.NoError(err)
-
-		r.Equal(map[string]any{
-			"code":    syscode.CodeHTTPMissingHeader,
-			"message": "missing X-Inngest-Signature header",
-		}, respBody)
-	})
-
-	t.Run("missing sync kind header", func(t *testing.T) {
-		// SDK attempts an out-of-band sync when the sync kind header is missing
-
-		r := require.New(t)
-		ctx := context.Background()
 
 		// Create a simple Go HTTP mockCloud that responds with hello world
+		var called int32
 		mockCloud := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&called, 1)
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"ok":true,"modified":true}`))
 		}))
@@ -1101,18 +1070,17 @@ func TestInBandSync(t *testing.T) {
 		server := httptest.NewServer(h)
 		defer server.Close()
 
-		sig, _ := Sign(ctx, time.Now(), []byte(testKey), reqBodyByt)
 		req, err := http.NewRequest(
 			http.MethodPut,
 			server.URL,
 			bytes.NewReader(reqBodyByt),
 		)
 		r.NoError(err)
-		req.Header.Set("x-inngest-signature", sig)
 		resp, err := http.DefaultClient.Do(req)
 		r.NoError(err)
 		r.Equal(http.StatusOK, resp.StatusCode)
 		r.Equal("out_of_band", resp.Header.Get("x-inngest-sync-kind"))
+		r.EqualValues(1, atomic.LoadInt32(&called))
 
 		respByt, err := io.ReadAll(resp.Body)
 		r.NoError(err)
@@ -1134,7 +1102,6 @@ func TestInBandSync(t *testing.T) {
 		)
 		r.NoError(err)
 		req.Header.Set("x-inngest-signature", sig)
-		req.Header.Set("x-inngest-sync-kind", "in_band")
 		resp, err := http.DefaultClient.Do(req)
 		r.NoError(err)
 		r.Equal(http.StatusOK, resp.StatusCode)

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -47,7 +47,7 @@ func startDevServer() (func() error, error) {
 	cmd := exec.Command(
 		"bash",
 		"-c",
-		"npx --yes inngest-cli@latest dev --no-discovery --no-poll",
+		"npx --ignore-scripts=false --yes inngest-cli@latest dev --no-discovery --no-poll",
 	)
 
 	// Run in a new process group so we can kill the process and its children


### PR DESCRIPTION
# Description

Authenticated syncs (a.k.a. in-band syncs) are always enabled. Remove ability to disable.

# Context

Unauthenticated syncs (a.k.a. out-of-band syncs) still work if the request is unsigned. We'll add an option to disable them in the future.

Note that unauthenticated syncs are not insecure. They just tell the SDK to sync itself using an outgoing request; they don't make the SDK return sensitive info in the response